### PR TITLE
macos-expert: restructure SKILL, add triggers, companion tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  validate:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: "pyproject.toml"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - name: Sync dependencies
+        run: uv sync --locked --group dev
+      - name: Validate Agent Skills spec
+        run: |
+          uv run agentskills validate git-spice
+          uv run agentskills validate macos-expert
+          uv run agentskills validate wise-mcp
+      - name: Run prek hooks
+        uses: j178/prek-action@v1
+        with:
+          extra-args: "--all-files typos markdownlint"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,7 @@ jobs:
       - name: Sync dependencies
         run: uv sync --locked --group dev
       - name: Validate Agent Skills spec
-        run: |
-          uv run agentskills validate git-spice
-          uv run agentskills validate macos-expert
-          uv run agentskills validate wise-mcp
+        run: uv run python scripts/validate_skills.py
       - name: Run prek hooks
         uses: j178/prek-action@0bb87d7f00b0c99306c8bcb8b8beba1eb581c037 # v1.1.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,13 @@ jobs:
   validate:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version-file: "pyproject.toml"
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
         with:
           enable-cache: true
       - name: Sync dependencies
@@ -27,6 +27,6 @@ jobs:
           uv run agentskills validate macos-expert
           uv run agentskills validate wise-mcp
       - name: Run prek hooks
-        uses: j178/prek-action@v1
+        uses: j178/prek-action@0bb87d7f00b0c99306c8bcb8b8beba1eb581c037 # v1.1.1
         with:
           extra-args: "--all-files typos markdownlint"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,7 @@ jobs:
           enable-cache: true
       - name: Sync dependencies
         run: uv sync --locked --group dev
-      - name: Validate Agent Skills spec
-        run: uv run python scripts/validate_skills.py
       - name: Run prek hooks
         uses: j178/prek-action@0bb87d7f00b0c99306c8bcb8b8beba1eb581c037 # v1.1.1
         with:
-          extra-args: "--all-files typos markdownlint"
+          extra-args: "--all-files agentskills-validate typos markdownlint"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .venv/
-uv.lock

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,5 @@
 {
   "MD013": false,
-  "MD032": false,
   "MD034": false,
   "MD036": false
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+  "MD013": false,
+  "MD032": false,
+  "MD034": false,
+  "MD036": false
+}

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The preferred workflow here is:
 
 1. Create the skill scaffold:
 
-    ```bash
+    ```bash path=null start=null
     skills init my-skill
     ```
 
@@ -87,7 +87,7 @@ The preferred workflow here is:
 
 4. Run repository validation from the root:
 
-    ```bash
+    ```bash path=null start=null
     prek run --all-files
     ```
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,15 @@ Validation tooling is configured at the repository root:
 
 - `pyproject.toml` provides the shared Python tooling definition
 - `prek.toml` runs formatting and quality checks across all skills in the repo
+- official Agent Skills spec validation runs via `uv run agentskills validate <skill-dir>`
 
 This is intentional: spell-checking, dead-link checking, TOML validation, and related checks should apply consistently to every skill instead of being duplicated inside each skill directory.
+
+Run the official skill validation for all current skills from the repo root with:
+
+```bash path=null start=null
+nu scripts/validate_skills.nu
+```
 
 If GitButler is managing `pre-commit`, prefer leaving that hook in place and using `prek` primarily for `pre-push`. This repo is configured so a plain `prek install` installs only `pre-push` by default, which avoids overwriting a custom or GitButler-managed `pre-commit` hook.
 
@@ -88,6 +95,7 @@ The preferred workflow here is:
 4. Run repository validation from the root:
 
     ```bash path=null start=null
+    uv run agentskills validate my-skill
     prek run --all-files
     ```
 

--- a/README.md
+++ b/README.md
@@ -60,15 +60,19 @@ If `pre-commit` gets replaced by a future explicit `prek install --hook-type pre
 ## Skills
 
 ### `macos-expert`
+
 Source-backed macOS app development guidance covering Apple HIG expectations, SwiftUI, AppKit, accessibility, file/document workflows, and platform capabilities.
 
 ### `git-spice`
+
 Working effectively with [git-spice](https://abhinav.github.io/git-spice/) for stacked branches and GitLab/GitHub merge requests.
 
 ### `wise-mcp`
+
 Building MCP servers with [FastMCP](https://github.com/PrefectHQ/fastmcp), informed by battle-tested agentic tool design patterns by [Arcade](https://www.arcade.dev/patterns).
 
 ## Adding a new skill
+
 The preferred workflow here is:
 
 1. Create the skill scaffold:
@@ -77,12 +81,12 @@ The preferred workflow here is:
 skills init my-skill
 ```
 
-2. Replace the generated `SKILL.md` with the real skill content
-3. Add any supporting `references/`, assets, or additional files the skill needs
-4. Run repository validation from the root:
+1. Replace the generated `SKILL.md` with the real skill content
+1. Add any supporting `references/`, assets, or additional files the skill needs
+1. Run repository validation from the root:
 
 ```bash path=null start=null
 prek run --all-files
 ```
 
-5. Commit the change in small, reviewable steps
+1. Commit the change in small, reviewable steps

--- a/README.md
+++ b/README.md
@@ -77,16 +77,18 @@ The preferred workflow here is:
 
 1. Create the skill scaffold:
 
-```bash path=null start=null
-skills init my-skill
-```
+    ```bash
+    skills init my-skill
+    ```
 
-1. Replace the generated `SKILL.md` with the real skill content
-1. Add any supporting `references/`, assets, or additional files the skill needs
-1. Run repository validation from the root:
+2. Replace the generated `SKILL.md` with the real skill content
 
-```bash path=null start=null
-prek run --all-files
-```
+3. Add any supporting `references/`, assets, or additional files the skill needs
 
-1. Commit the change in small, reviewable steps
+4. Run repository validation from the root:
+
+    ```bash
+    prek run --all-files
+    ```
+
+5. Commit the change in small, reviewable steps

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ Validation tooling is configured at the repository root:
 
 - `pyproject.toml` provides the shared Python tooling definition
 - `prek.toml` runs formatting and quality checks across all skills in the repo
-- official Agent Skills spec validation runs via `uv run agentskills validate <skill-dir>`
+- official Agent Skills spec validation runs via `scripts/validate_skills.py`, which discovers top-level skill directories and invokes `uv run agentskills validate <skill-dir>` for each one
 
 This is intentional: spell-checking, dead-link checking, TOML validation, and related checks should apply consistently to every skill instead of being duplicated inside each skill directory.
 
 Run the official skill validation for all current skills from the repo root with:
 
 ```bash path=null start=null
-nu scripts/validate_skills.nu
+uv run python scripts/validate_skills.py
 ```
 
 If GitButler is managing `pre-commit`, prefer leaving that hook in place and using `prek` primarily for `pre-push`. This repo is configured so a plain `prek install` installs only `pre-push` by default, which avoids overwriting a custom or GitButler-managed `pre-commit` hook.
@@ -95,7 +95,7 @@ The preferred workflow here is:
 4. Run repository validation from the root:
 
     ```bash path=null start=null
-    uv run agentskills validate my-skill
+    uv run python scripts/validate_skills.py
     prek run --all-files
     ```
 

--- a/macos-expert/SKILL.md
+++ b/macos-expert/SKILL.md
@@ -1,11 +1,29 @@
 ---
 name: macos-expert
-description: Comprehensive modern macOS app development guidance grounded in Apple’s Human Interface Guidelines and official Apple developer documentation. Use when building, reviewing, or refactoring macOS software with SwiftUI, AppKit, AppKit-SwiftUI bridging, SwiftData, accessibility, menus, windows, toolbars, sidebars, document and file workflows, drag and drop, sandboxing, distribution, or other Mac-specific platform behavior.
+description: Comprehensive modern macOS app development guidance grounded in Apple's Human Interface Guidelines and official Apple developer documentation. Use when building, reviewing, or refactoring macOS software with SwiftUI, AppKit, AppKit-SwiftUI bridging, SwiftData, accessibility, menus, windows, toolbars, sidebars, document and file workflows, drag and drop, sandboxing, distribution, or other Mac-specific platform behavior.
 ---
 
 # macos-expert
 
 Use this skill to keep macOS work native, modern, and source-backed.
+
+## When to use
+
+- Building, reviewing, or refactoring a macOS app with SwiftUI, AppKit, or both
+- Designing windows, toolbars, sidebars, menus, commands, or keyboard shortcuts for macOS
+- Implementing document-based apps, file import/export, open/save panels, or Quick Look
+- Working with drag and drop, clipboard, undo/redo, or context menus
+- Adding or auditing VoiceOver, keyboard navigation, focus, contrast, or motion accessibility
+- Choosing between SwiftData, Core Data, UserDefaults, or file-based persistence
+- Bridging AppKit and SwiftUI with NSHostingView, NSViewRepresentable, or coordinators
+- Configuring sandboxing, entitlements, security-scoped bookmarks, or App Groups
+- Building menu bar apps with MenuBarExtra or NSStatusItem
+- Setting up login items, extensions, signing, notarization, or distribution
+- Reviewing whether a macOS app feels native or carries iOS anti-patterns
+
+## Recommended companion tools
+
+Using [Sosumi](https://sosumi.ai/) alongside this skill is highly recommended. Sosumi provides direct access to Apple Developer documentation and Human Interface Guidelines as Markdown, making it easy to verify APIs, symbols, and platform behavior referenced in this skill against current official sources.
 
 ## Source priority
 
@@ -18,18 +36,6 @@ If a named API, symbol, modifier, entitlement, or platform behavior is uncertain
 
 Start with `references/official-sources.md` if you need the verification workflow or the canonical Apple source map.
 
-## Load the right references
-
-- Read `references/designing-for-macos.md` for macOS-first product and UX decisions
-- Read `references/windows-navigation.md` for windows, toolbars, sidebars, sheets, popovers, inspectors, and full-screen behavior
-- Read `references/menus-commands-input.md` for menu bar structure, commands, shortcuts, undo/redo, clipboard, pointer, keyboard, and drag-and-drop expectations
-- Read `references/file-management-documents.md` for open/save/import/export, document workflows, file access, Quick Look, and Finder-facing behavior
-- Read `references/accessibility.md` for VoiceOver, keyboard navigation, focus, contrast, motion, and testing
-- Read `references/swiftui-macos.md` for modern SwiftUI patterns specific to macOS
-- Read `references/appkit-and-bridging.md` for AppKit-heavy work and AppKit-SwiftUI integration
-- Read `references/persistence-and-data.md` for SwiftData, Core Data, document data, settings, and migration choices
-- Read `references/platform-capabilities-distribution.md` for sandboxing, bookmarks, extensions, menu bar apps, login items, signing, notarization, and distribution
-
 ## Core workflow
 
 1. Classify the task: design review, implementation, migration, bug fix, architecture, or distribution
@@ -39,6 +45,27 @@ Start with `references/official-sources.md` if you need the verification workflo
 5. Call out version constraints, fallback paths, and trade-offs explicitly
 6. Distinguish design guidance from API guidance
 
+## Load the right references
+
+- Read `references/designing-for-macos.md` for macOS-first product and UX decisions
+  - *Triggers: design review, native feel, platform expectations, Mac vs iPad patterns, layout density*
+- Read `references/windows-navigation.md` for windows, toolbars, sidebars, sheets, popovers, inspectors, and full-screen behavior
+  - *Triggers: WindowGroup, DocumentGroup, NavigationSplitView, NSWindow, NSToolbar, NSSplitViewController, toolbar, sidebar, inspector, sheet, popover, full-screen, window resize*
+- Read `references/menus-commands-input.md` for menu bar structure, commands, shortcuts, undo/redo, clipboard, pointer, keyboard, and drag-and-drop expectations
+  - *Triggers: menu bar, NSMenu, .commands, CommandGroup, keyboard shortcut, ⌘, undo, redo, copy, paste, context menu, drag and drop, .draggable, .dropDestination, NSDraggingSource, Dock menu*
+- Read `references/file-management-documents.md` for open/save/import/export, document workflows, file access, Quick Look, and Finder-facing behavior
+  - *Triggers: DocumentGroup, FileDocument, ReferenceFileDocument, NSDocument, NSOpenPanel, NSSavePanel, .fileImporter, .fileExporter, UTType, Quick Look, Finder, open panel, save panel, recent documents*
+- Read `references/accessibility.md` for VoiceOver, keyboard navigation, focus, contrast, motion, and testing
+  - *Triggers: VoiceOver, accessibility, .accessibilityLabel, NSAccessibility, focus, keyboard navigation, contrast, reduce motion, assistive technology*
+- Read `references/swiftui-macos.md` for modern SwiftUI patterns specific to macOS
+  - *Triggers: SwiftUI on macOS, NavigationSplitView, Table, MenuBarExtra, Settings, .searchable, @FocusState, Observation, scene, SwiftUI commands, SwiftUI toolbar*
+- Read `references/appkit-and-bridging.md` for AppKit-heavy work and AppKit-SwiftUI integration
+  - *Triggers: AppKit, NSHostingView, NSHostingController, NSViewRepresentable, NSViewControllerRepresentable, coordinator, bridging, responder chain, NSTableView, NSOutlineView*
+- Read `references/persistence-and-data.md` for SwiftData, Core Data, document data, settings, and migration choices
+  - *Triggers: SwiftData, Core Data, @Query, ModelActor, FetchDescriptor, @AppStorage, UserDefaults, persistence, migration, schema, database*
+- Read `references/platform-capabilities-distribution.md` for sandboxing, bookmarks, extensions, menu bar apps, login items, signing, notarization, and distribution
+  - *Triggers: sandbox, entitlement, security-scoped bookmark, App Group, SMAppService, login item, MenuBarExtra, NSStatusItem, extension, Finder Sync, XPC, notarization, Developer ID, Hardened Runtime, Mac App Store, distribution*
+
 ## Non-negotiables
 
 - Prefer Apple-standard windows, toolbars, menus, commands, shortcuts, dialogs, and file flows
@@ -47,6 +74,16 @@ Start with `references/official-sources.md` if you need the verification workflo
 - Treat keyboard support, context menus, drag and drop, and undo/redo as core Mac affordances
 - If custom UI replaces a standard control, preserve discoverability, keyboard support, and accessibility semantics
 - Avoid version-specific or newly announced platform claims unless verified against current official docs
+
+## Common anti-patterns
+
+- Hiding core actions behind a single overflow menu instead of using the menu bar and toolbar
+- Giant touch-sized controls that waste space on desktop
+- No keyboard navigation, no shortcuts, or no context menus
+- Replacing standard window chrome or toolbar behavior without a strong reason
+- Building custom file pickers instead of using system open/save panels
+- Treating drag and drop as optional in workflows where files or lists are central
+- Importing iOS tab bars, bottom sheets, or navigation stacks where Mac-native sidebars, inspectors, or split views belong
 
 ## Response expectations
 

--- a/macos-expert/references/accessibility.md
+++ b/macos-expert/references/accessibility.md
@@ -74,3 +74,10 @@ Accessibility is part of correctness on macOS, not an optional polish pass.
 - Focus does not jump unpredictably
 - Complex rows, custom controls, and tables remain understandable to VoiceOver
 - Contrast and motion settings are respected
+
+## Pair this file with
+
+- `designing-for-macos.md` for macOS interaction expectations that affect accessibility
+- `menus-commands-input.md` for keyboard shortcuts and command coverage
+- `swiftui-macos.md` for SwiftUI accessibility modifiers and focus APIs
+- `appkit-and-bridging.md` for AppKit accessibility overrides and bridging concerns

--- a/macos-expert/references/appkit-and-bridging.md
+++ b/macos-expert/references/appkit-and-bridging.md
@@ -51,3 +51,10 @@ This is the best default when SwiftUI is the shell but specific controls still n
 - Coordinators, delegates, and notifications are cleaned up correctly
 - Layout and resizing remain stable
 - Standard AppKit controls are preferred over unnecessary custom widgets
+
+## Pair this file with
+
+- `swiftui-macos.md` for SwiftUI-first patterns and when SwiftUI is enough
+- `windows-navigation.md` for AppKit window, toolbar, and split-view details
+- `menus-commands-input.md` for responder chain, menu validation, and drag-and-drop
+- `accessibility.md` for AppKit accessibility overrides and testing

--- a/macos-expert/references/file-management-documents.md
+++ b/macos-expert/references/file-management-documents.md
@@ -67,3 +67,10 @@ File handling is a core Mac experience. Prefer standard system flows over custom
 - Drag-and-drop supports common file workflows
 - File access rules and sandbox implications are handled correctly
 - Custom file types are previewable and well-integrated where appropriate
+
+## Pair this file with
+
+- `menus-commands-input.md` for drag-and-drop, clipboard, and file-related commands
+- `persistence-and-data.md` for choosing between file-based and database-backed storage
+- `platform-capabilities-distribution.md` for sandboxing, entitlements, and security-scoped bookmarks
+- `swiftui-macos.md` for SwiftUI file workflow APIs

--- a/macos-expert/references/menus-commands-input.md
+++ b/macos-expert/references/menus-commands-input.md
@@ -119,3 +119,10 @@ Treat drag and drop as a core Mac affordance in file-centric and list-centric ap
 - Undo/redo and copy/paste exist where users expect them
 - Context menus and drag-and-drop improve workflows instead of duplicating clutter
 - Keyboard navigation is complete enough for expert use
+
+## Pair this file with
+
+- `designing-for-macos.md` for macOS-first product and interaction expectations
+- `windows-navigation.md` for toolbar placement and window structure
+- `accessibility.md` for keyboard navigation and focus requirements
+- `file-management-documents.md` for drag-and-drop file workflows

--- a/macos-expert/references/persistence-and-data.md
+++ b/macos-expert/references/persistence-and-data.md
@@ -48,3 +48,9 @@ Do not force a database-shaped UX onto a document-shaped product.
 - File/document workflows are file-native when appropriate
 - Preferences are separated from user content
 - Background work, fetch size, and migration risks are considered
+
+## Pair this file with
+
+- `file-management-documents.md` for document-based app workflows and file storage
+- `swiftui-macos.md` for SwiftUI data flow and observation patterns
+- `platform-capabilities-distribution.md` for App Groups, sandboxing, and shared containers

--- a/macos-expert/references/platform-capabilities-distribution.md
+++ b/macos-expert/references/platform-capabilities-distribution.md
@@ -46,3 +46,10 @@ Do not add an extension target just to mirror functionality that belongs in the 
 - extension boundaries are appropriate
 - privacy descriptions are accurate
 - signing, notarization, and distribution paths are planned early enough to avoid late surprises
+
+## Pair this file with
+
+- `file-management-documents.md` for sandboxed file access and security-scoped bookmarks
+- `persistence-and-data.md` for App Group containers and shared storage
+- `swiftui-macos.md` for MenuBarExtra and SwiftUI scene types
+- `official-sources.md` for verifying entitlements and Info.plist keys

--- a/macos-expert/references/swiftui-macos.md
+++ b/macos-expert/references/swiftui-macos.md
@@ -57,3 +57,10 @@ Bridge to AppKit when you need:
 - Observation and state lifetimes are clean
 - Mac-specific affordances are present instead of emulated
 - AppKit is introduced only where SwiftUI meaningfully falls short
+
+## Pair this file with
+
+- `appkit-and-bridging.md` for when and how to bridge to AppKit
+- `windows-navigation.md` for window, toolbar, and navigation layout guidance
+- `menus-commands-input.md` for commands, shortcuts, and menu structure
+- `persistence-and-data.md` for SwiftData and document storage choices

--- a/macos-expert/references/windows-navigation.md
+++ b/macos-expert/references/windows-navigation.md
@@ -75,3 +75,10 @@ Use tabs only when sections are true peers and do not benefit from a shared side
 - The app uses sidebars and inspectors where macOS users expect them
 - Full-screen is supported sensibly for content-heavy tasks
 - Auxiliary windows exist only when they represent a real separate workspace
+
+## Pair this file with
+
+- `designing-for-macos.md` for broader macOS product and UX expectations
+- `menus-commands-input.md` for toolbar actions, commands, and shortcuts
+- `swiftui-macos.md` for SwiftUI scene and navigation API patterns
+- `appkit-and-bridging.md` for AppKit window and split-view details

--- a/prek.toml
+++ b/prek.toml
@@ -25,7 +25,7 @@ hooks = [
 [[repos]]
 repo = "https://github.com/crate-ci/typos"
 rev = "v1.44.0"  # prek autoupdate will fill this
-hooks = [{ id = "typos", priority = 1 }]
+hooks = [{ id = "typos", priority = 1, stages = ["pre-push"] }]
 
 [[repos]]
 repo = "local"

--- a/prek.toml
+++ b/prek.toml
@@ -34,5 +34,5 @@ hooks = [{ id = "markdownlint", priority = 1 }]
 
 [[repos]]
 repo = "https://github.com/lycheeverse/lychee"
-rev = "nightly"  # lychee tags nightly as latest; prek autoupdate may switch to it
+rev = "lychee-v0.23.0"  # lychee tags nightly as latest; prek autoupdate may switch to it
 hooks = [{ id = "lychee", args = ["--no-progress"], priority = 1, stages = ["pre-push"], types_or = ["markdown"] }]

--- a/prek.toml
+++ b/prek.toml
@@ -30,7 +30,7 @@ hooks = [{ id = "typos", priority = 1 }]
 [[repos]]
 repo = "local"
 hooks = [
-    { id = "agentskills-validate", name = "Validate Agent Skills spec", language = "system", entry = "nu scripts/validate_skills.nu", pass_filenames = false, always_run = true, stages = ["pre-push"], priority = 1 },
+    { id = "agentskills-validate", name = "Validate Agent Skills spec", language = "system", entry = "uv run python scripts/validate_skills.py", pass_filenames = false, always_run = true, stages = ["pre-push"], priority = 1 },
 ]
 
 [[repos]]

--- a/prek.toml
+++ b/prek.toml
@@ -24,7 +24,7 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/crate-ci/typos"
-rev = "v1.43.4"  # prek autoupdate will fill this
+rev = "v1.44.0"  # prek autoupdate will fill this
 hooks = [{ id = "typos", priority = 1 }]
 
 [[repos]]
@@ -34,5 +34,5 @@ hooks = [{ id = "markdownlint", priority = 1 }]
 
 [[repos]]
 repo = "https://github.com/lycheeverse/lychee"
-rev = "lychee-v0.23.0"  # lychee tags nightly as latest; prek autoupdate may switch to it
+rev = "nightly"  # lychee tags nightly as latest; prek autoupdate may switch to it
 hooks = [{ id = "lychee", args = ["--no-progress"], priority = 1, stages = ["pre-push"], types_or = ["markdown"] }]

--- a/prek.toml
+++ b/prek.toml
@@ -30,7 +30,7 @@ hooks = [{ id = "typos", priority = 1 }]
 [[repos]]
 repo = "https://github.com/igorshubovych/markdownlint-cli"
 rev = "v0.48.0"
-hooks = [{ id = "markdownlint", priority = 1 }]
+hooks = [{ id = "markdownlint", priority = 1, stages = ["pre-commit"], types_or = ["markdown"] }]
 
 [[repos]]
 repo = "https://github.com/lycheeverse/lychee"

--- a/prek.toml
+++ b/prek.toml
@@ -28,6 +28,11 @@ rev = "v1.43.4"  # prek autoupdate will fill this
 hooks = [{ id = "typos", priority = 1 }]
 
 [[repos]]
+repo = "https://github.com/igorshubovych/markdownlint-cli"
+rev = "v0.48.0"
+hooks = [{ id = "markdownlint", priority = 1 }]
+
+[[repos]]
 repo = "https://github.com/lycheeverse/lychee"
 rev = "lychee-v0.23.0"  # lychee tags nightly as latest; prek autoupdate may switch to it
 hooks = [{ id = "lychee", args = ["--no-progress"], priority = 1, stages = ["pre-push"], types_or = ["markdown"] }]

--- a/prek.toml
+++ b/prek.toml
@@ -28,6 +28,12 @@ rev = "v1.44.0"  # prek autoupdate will fill this
 hooks = [{ id = "typos", priority = 1 }]
 
 [[repos]]
+repo = "local"
+hooks = [
+    { id = "agentskills-validate", name = "Validate Agent Skills spec", language = "system", entry = "nu scripts/validate_skills.nu", pass_filenames = false, always_run = true, stages = ["pre-push"], priority = 1 },
+]
+
+[[repos]]
 repo = "https://github.com/igorshubovych/markdownlint-cli"
 rev = "v0.48.0"
 hooks = [{ id = "markdownlint", priority = 1, stages = ["pre-push"], types_or = ["markdown"] }]

--- a/prek.toml
+++ b/prek.toml
@@ -30,7 +30,7 @@ hooks = [{ id = "typos", priority = 1 }]
 [[repos]]
 repo = "https://github.com/igorshubovych/markdownlint-cli"
 rev = "v0.48.0"
-hooks = [{ id = "markdownlint", priority = 1, stages = ["pre-commit"], types_or = ["markdown"] }]
+hooks = [{ id = "markdownlint", priority = 1, stages = ["pre-push"], types_or = ["markdown"] }]
 
 [[repos]]
 repo = "https://github.com/lycheeverse/lychee"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,4 +7,5 @@ dependencies = []
 [dependency-groups]
 dev = [
     "prek>=0.3.4,<0.4",
+    "skills-ref>=0.1.1",
 ]

--- a/scripts/validate_skills.nu
+++ b/scripts/validate_skills.nu
@@ -1,0 +1,6 @@
+let skills = ["git-spice" "macos-expert" "wise-mcp"]
+
+for skill in $skills {
+  print $"== ($skill) =="
+  uv run agentskills validate $skill
+}

--- a/scripts/validate_skills.nu
+++ b/scripts/validate_skills.nu
@@ -1,6 +1,0 @@
-let skills = ["git-spice" "macos-expert" "wise-mcp"]
-
-for skill in $skills {
-  print $"== ($skill) =="
-  uv run agentskills validate $skill
-}

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -6,7 +6,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
-def iter_skill_directories() -> list[str]:
+def get_skill_directories() -> list[str]:
     skills = sorted(
         path.name
         for path in REPO_ROOT.iterdir()
@@ -20,7 +20,7 @@ def iter_skill_directories() -> list[str]:
 def main() -> int:
     failures: list[str] = []
 
-    for skill in iter_skill_directories():
+    for skill in get_skill_directories():
         print(f"== {skill} ==")
         result = subprocess.run(
             ["uv", "run", "agentskills", "validate", skill],

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def iter_skill_directories() -> list[str]:
+    skills = sorted(
+        path.name
+        for path in REPO_ROOT.iterdir()
+        if path.is_dir() and not path.name.startswith(".") and (path / "SKILL.md").is_file()
+    )
+    if not skills:
+        raise SystemExit("No skill directories with SKILL.md were found.")
+    return skills
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    for skill in iter_skill_directories():
+        print(f"== {skill} ==")
+        result = subprocess.run(
+            ["uv", "run", "agentskills", "validate", skill],
+            cwd=REPO_ROOT,
+            check=False,
+        )
+        if result.returncode != 0:
+            failures.append(skill)
+
+    if failures:
+        print()
+        print("Validation failed for:")
+        for skill in failures:
+            print(f"- {skill}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,113 @@
+version = 1
+revision = 3
+requires-python = ">=3.14"
+
+[[package]]
+name = "agent-skills"
+version = "0.1.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "prek" },
+    { name = "skills-ref" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "prek", specifier = ">=0.3.4,<0.4" },
+    { name = "skills-ref", specifier = ">=0.1.1" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "prek"
+version = "0.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/51/2324eaad93a4b144853ca1c56da76f357d3a70c7b4fd6659e972d7bb8660/prek-0.3.4.tar.gz", hash = "sha256:56a74d02d8b7dfe3c774ecfcd8c1b4e5f1e1b84369043a8003e8e3a779fce72d", size = 356633, upload-time = "2026-02-28T03:47:13.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/20/1a964cb72582307c2f1dc7f583caab90f42810ad41551e5220592406a4c3/prek-0.3.4-py3-none-linux_armv6l.whl", hash = "sha256:c35192d6e23fe7406bd2f333d1c7dab1a4b34ab9289789f453170f33550aa74d", size = 4641915, upload-time = "2026-02-28T03:47:03.772Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/cb/4a21f37102bac37e415b61818344aa85de8d29a581253afa7db8c08d5a33/prek-0.3.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6f784d78de72a8bbe58a5fe7bde787c364ae88f0aff5222c5c5c7287876c510a", size = 4649166, upload-time = "2026-02-28T03:47:06.164Z" },
+    { url = "https://files.pythonhosted.org/packages/85/9c/a7c0d117a098d57931428bdb60fcb796e0ebc0478c59288017a2e22eca96/prek-0.3.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:50a43f522625e8c968e8c9992accf9e29017abad6c782d6d176b73145ad680b7", size = 4274422, upload-time = "2026-02-28T03:46:59.356Z" },
+    { url = "https://files.pythonhosted.org/packages/59/84/81d06df1724d09266df97599a02543d82fde7dfaefd192f09d9b2ccb092f/prek-0.3.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:4bbb1d3912a88935f35c6ba4466b4242732e3e3a8c608623c708e83cea85de00", size = 4629873, upload-time = "2026-02-28T03:46:56.419Z" },
+    { url = "https://files.pythonhosted.org/packages/09/cd/bb0aefa25cfacd8dbced75b9a9d9945707707867fa5635fb69ae1bbc2d88/prek-0.3.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ca4d4134db8f6e8de3c418317becdf428957e3cab271807f475318105fd46d04", size = 4552507, upload-time = "2026-02-28T03:47:05.004Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/c0/578a7af4861afb64ec81c03bfdcc1bb3341bb61f2fff8a094ecf13987a56/prek-0.3.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7fb6395f6eb76133bb1e11fc718db8144522466cdc2e541d05e7813d1bbcae7d", size = 4865929, upload-time = "2026-02-28T03:47:09.231Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/48/f169406590028f7698ef2e1ff5bffd92ca05e017636c1163a2f5ef0f8275/prek-0.3.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:aae17813239ddcb4ae7b38418de4d49afff740f48f8e0556029c96f58e350412", size = 5390286, upload-time = "2026-02-28T03:47:10.796Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c5/98a73fec052059c3ae06ce105bef67caca42334c56d84e9ef75df72ba152/prek-0.3.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10a621a690d9c127afc3d21c275030d364d1fbef3296c095068d3ae80a59546e", size = 4891028, upload-time = "2026-02-28T03:47:07.916Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/b4/029966e35e59b59c142be7e1d2208ad261709ac1a66aa4a3ce33c5b9f91f/prek-0.3.4-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:d978c31bc3b1f0b3d58895b7c6ac26f077e0ea846da54f46aeee4c7088b1b105", size = 4633986, upload-time = "2026-02-28T03:47:14.351Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/27/d122802555745b6940c99fcb41496001c192ddcdf56ec947ec10a0298e05/prek-0.3.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a8e089a030f0a023c22a4bb2ec4ff3fcc153585d701cff67acbfca2f37e173ae", size = 4680722, upload-time = "2026-02-28T03:47:12.224Z" },
+    { url = "https://files.pythonhosted.org/packages/34/40/92318c96b3a67b4e62ed82741016ede34d97ea9579d3cc1332b167632222/prek-0.3.4-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:8060c72b764f0b88112616763da9dd3a7c293e010f8520b74079893096160a2f", size = 4535623, upload-time = "2026-02-28T03:46:52.221Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f5/6b383d94e722637da4926b4f609d36fe432827bb6f035ad46ee02bde66b6/prek-0.3.4-py3-none-musllinux_1_1_i686.whl", hash = "sha256:65b23268456b5a763278d4e1ec532f2df33918f13ded85869a1ddff761eb9697", size = 4729879, upload-time = "2026-02-28T03:46:57.886Z" },
+    { url = "https://files.pythonhosted.org/packages/79/f8/fdc705b807d813fd713ffa4f67f96741542ed1dafbb221206078c06f3df4/prek-0.3.4-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:3975c61139c7b3200e38dc3955e050b0f2615701d3deb9715696a902e850509e", size = 5001569, upload-time = "2026-02-28T03:47:00.892Z" },
+    { url = "https://files.pythonhosted.org/packages/84/92/b007a41f58e8192a1e611a21b396ad870d51d7873b7af12068ebae7fc15f/prek-0.3.4-py3-none-win32.whl", hash = "sha256:37449ae82f4dc08b72e542401e3d7318f05d1163e87c31ab260a40f425d6516e", size = 4297057, upload-time = "2026-02-28T03:47:02.219Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dc/bcb02de9b11461e8e0c7d3c8fdf8cfa15ac6efe73472a4375549ba5defd2/prek-0.3.4-py3-none-win_amd64.whl", hash = "sha256:60e9aa86ca65de963510ae28c5d94b9d7a97bcbaa6e4cdb5bf5083ed4c45dc71", size = 4655174, upload-time = "2026-02-28T03:46:53.749Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/86/98f5598569f4cd3de7161e266fab6a8981e65555f79d4704810c1502ad0a/prek-0.3.4-py3-none-win_arm64.whl", hash = "sha256:486bdae8f4512d3b4f6eb61b83e5b7595da2adca385af4b2b7823c0ab38d1827", size = 4367817, upload-time = "2026-02-28T03:46:55.264Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "skills-ref"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "strictyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/42/943d3ba8b097af7068b7178563a5062ad8a977982f4a7b4f67facfc575e9/skills_ref-0.1.1.tar.gz", hash = "sha256:6b400ca6e0049be62dca0167ff943ba2745fd67efb37fbba4d0ee341fccd2695", size = 93519, upload-time = "2026-01-10T13:23:41.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/25/36a43c3a61fb6cc3984e6ad5e556929b8ae71c95eba615dae4cf2f427964/skills_ref-0.1.1-py3-none-any.whl", hash = "sha256:d35db5bb8de71ae301daf5ca9cb71f8a555e8c6f83a6d40e46a5bc09f8f461b5", size = 12918, upload-time = "2026-01-10T13:23:40.106Z" },
+]
+
+[[package]]
+name = "strictyaml"
+version = "1.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/08/efd28d49162ce89c2ad61a88bd80e11fb77bc9f6c145402589112d38f8af/strictyaml-1.7.3.tar.gz", hash = "sha256:22f854a5fcab42b5ddba8030a0e4be51ca89af0267961c8d6cfa86395586c407", size = 115206, upload-time = "2023-03-10T12:50:27.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/7c/a81ef5ef10978dd073a854e0fa93b5d8021d0594b639cc8f6453c3c78a1d/strictyaml-1.7.3-py3-none-any.whl", hash = "sha256:fb5c8a4edb43bebb765959e420f9b3978d7f1af88c80606c03fb420888f5d1c7", size = 123917, upload-time = "2023-03-10T12:50:17.242Z" },
+]

--- a/wise-mcp/SKILL.md
+++ b/wise-mcp/SKILL.md
@@ -27,6 +27,7 @@ This skill guides you through building high-quality MCP servers using FastMCP (P
 ### 1. Before you start
 
 Fetch the latest documentation before writing any code:
+
 - Read https://gofastmcp.com/llms-full.txt for current FastMCP API, decorators, and patterns
 - Read https://www.arcade.dev/patterns/llm.txt for the full pattern catalog with explanations
 


### PR DESCRIPTION
# Important Changes

- Restructured SKILL file with workflow-first reading order
- Added explicit "When to use" activation signals for macos-expert skill
- Enriched reference files with trigger keywords for better prompt matching
- Added "Common anti-patterns" section
- Added "Pair this file with" cross-references across reference files
- Recommended Sosumi as companion tool for verifying Apple docs
- Removed stale Python artifacts from skill directory
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/agent-skills/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
