### PR TITLE
macos-expert: reality pass on SwiftUI gaps, AppKit triggers, and triage

### DIFF
--- a/macos-expert/README.md
+++ b/macos-expert/README.md
@@ -1,19 +1,33 @@
 # macos-expert
 
-An [Agent Skill](https://agentskills.io) for modern macOS development that is explicitly grounded in Apple’s Human Interface Guidelines and official Apple developer documentation.
+An [Agent Skill](https://agentskills.io) for modern macOS development, explicitly grounded in Apple's Human Interface Guidelines and official Apple developer documentation.
 
-The goal is not just “Swift on desktop.” The goal is Mac-native product and engineering guidance: windows, menus, toolbars, sidebars, file workflows, accessibility, SwiftUI, AppKit, bridging, persistence, sandboxing, menu bar apps, and shipping.
+The goal is not "Swift on desktop." The goal is Mac-native product and engineering guidance: windows, menus, toolbars, sidebars, file workflows, accessibility, SwiftUI, AppKit, bridging, persistence, sandboxing, menu bar apps, and shipping. The skill is opinionated about when SwiftUI is enough, when AppKit is required, and when bridging is the right answer — because the wrong call here produces apps that look like Mac apps but feel like iPad apps in a window.
 
 ## Design goals
 
 - Cover the major areas Apple emphasizes for macOS without the obvious gaps
+- Reflect reality, not framework marketing — name the documented SwiftUI gaps and tell the agent when to bridge to AppKit
 - Prefer stable, official Apple guidance over trend-driven or speculative platform claims
 - Keep the skill cohesive and self-contained
-- Keep `SKILL.md` concise and push depth into focused reference files
+- Keep `SKILL.md` concise (with the Shape A vs Shape B triage rubric near the top) and push depth into focused reference files
+
+## What this skill is honest about
+
+The reference files explicitly call out concrete SwiftUI macOS gaps that Apple's own documentation acknowledges or implies:
+
+- `.contextMenu` has no "menu is open" signal and no focus-ring styling on the right-clicked row
+- `.draggable` has no session-end / cancel callback (no SwiftUI equivalent to `NSDraggingSource.draggingSession(_:endedAt:operation:)`)
+- `onMoveCommand` is macOS / tvOS only — not iOS or iPadOS
+- `TextField` consumes arrow keys for cursor movement, breaking Spotlight-style search-with-arrow-nav patterns
+- `ToolbarItemPlacement` semantic placements are platform-variable by design (Apple's own wording)
+- `backgroundProminence` works only inside `List` and `Table`, not in custom rows
+
+The skill names the AppKit alternative for each gap rather than inventing SwiftUI workarounds.
 
 ## Source policy
 
-This skill was built from Apple’s own macOS design and developer documentation first, then synthesized into practical reference modules for repeated use.
+This skill was built from Apple's own macOS design and developer documentation, plus practical experience with real Mac apps that exercise the boundaries between SwiftUI and AppKit (NetNewsWire's AppKit-shell pattern, Ruddarr's SwiftUI-only pattern).
 
 ## Primary Apple HIG pages used
 
@@ -37,146 +51,104 @@ This skill was built from Apple’s own macOS design and developer documentation
 - ServiceManagement
 - Quick Look
 - Uniform Type Identifiers
+- Core Transferable
 
 ## Sosumi verification notes
 
-During authoring and review, the Sosumi MCP server was used to cross-check concrete Apple symbols and documentation pages. The skill files themselves intentionally refer only to official Apple documentation.
+During authoring and review, the Sosumi MCP server was used to cross-check concrete Apple symbols and documentation pages. The skill files refer only to official Apple documentation.
 
-The following symbols or APIs were explicitly checked this way while building the skill:
+The following symbols, modifiers, and concepts were explicitly verified against Apple's docs while building the skill, with particular attention to availability lines and discussion sections:
 
-- `DocumentGroup`
-- `MenuBarExtra`
-- `ModelActor`
-- `fileImporter`
-- `NSHostingView`
+- `Window`, `WindowGroup`, `Settings`, `DocumentGroup`, `MenuBarExtra`
+- `NavigationSplitView` (and its auto-added sidebar toggle)
+- `Table` (selection, sort, hierarchy, customization)
+- `ToolbarItemPlacement` (semantic vs positional placements; overflow language)
+- `.contextMenu(menuItems:)`, `.contextMenu(forSelectionType:menu:primaryAction:)`
+- `.draggable(_:)`, `.draggable(_:preview:)`
+- `onMoveCommand(perform:)` (macOS / tvOS only — confirmed)
+- `onKeyPress(_:action:)` and variants
+- `@Environment(\.appearsActive)` (replacement for `controlActiveState`)
+- `@Environment(\.backgroundProminence)` (with `List`/`Table` constraint confirmed)
+- `.focusable(_:)`, `@FocusState`
+- `.listRowBackground`, `.tableStyle`
+- `NSHostingView`, `NSHostingController`
+- `NSDraggingSource` (full lifecycle: `willBeginAt`, `movedTo`, `endedAt:operation:`)
+- `NSFilePromiseProvider`
 - `SMAppService`
+- `notarytool`
 
 ## Module-by-module source map
 
 ### `SKILL.md`
 
-Synthesized from the Apple sources below plus the repo’s existing skill structure conventions.
+Synthesized from Apple sources plus the Shape A / Shape B triage rubric derived from observing how real Mac apps split responsibilities between SwiftUI and AppKit.
 
 ### `references/official-sources.md`
 
-Primary basis:
+Primary basis: Apple HIG as design source of truth, Apple Developer docs as API source of truth.
 
-- Apple HIG as the design source of truth
-- Apple Developer docs as the API source of truth
-
-Purpose:
-
-- Make future updates verifiable instead of guess-driven
+Emphasis: making future updates verifiable, with explicit guidance on reading "Available on" lines and Discussion sections that document API constraints.
 
 ### `references/designing-for-macos.md`
 
-Primary basis:
+Primary basis: `Designing for macOS` HIG plus related guidance on windows, menus, toolbars, sidebars, drag and drop, and full-screen.
 
-- `Designing for macOS`
-- related HIG guidance on windows, menus, toolbars, sidebars, drag and drop, and full-screen behavior
-
-Emphasis:
-
-- a review lens that turns Apple’s HIG principles into practical macOS product heuristics
+Emphasis: practical macOS product heuristics, with concrete "iPad-in-a-window" anti-pattern signals.
 
 ### `references/windows-navigation.md`
 
-Primary basis:
+Primary basis: HIG pages for windows, toolbars, sidebars; SwiftUI scene and navigation APIs; AppKit window and split-view APIs.
 
-- HIG pages for windows, toolbars, sidebars, and full-screen behavior
-- SwiftUI scene and navigation APIs
-- AppKit window and split-view APIs
-
-Emphasis:
-
-- standard Mac windowing and navigation patterns over version-fashionable design framing
+Emphasis: matching scene types to workflows; the `ToolbarItemPlacement` non-determinism caveat; when `NSToolbar` beats `.toolbar`.
 
 ### `references/menus-commands-input.md`
 
-Primary basis:
+Primary basis: HIG menu and Dock-menu guidance; SwiftUI command APIs; AppKit menu and responder-chain patterns.
 
-- HIG guidance for menus, the menu bar, Dock menus, and drag-and-drop
-- standard macOS command and shortcut expectations
-- SwiftUI command APIs and AppKit menu/responder-chain patterns
-
-Emphasis:
-
-- standard commands, shortcuts, menus, and drag-and-drop as first-class Mac UI
+Emphasis: standard commands as first-class Mac UI, plus the SwiftUI keyboard and drag-lifecycle gaps with concrete bridging signals.
 
 ### `references/file-management-documents.md`
 
-Primary basis:
+Primary basis: HIG file-management guidance; document-based app patterns; SwiftUI file workflow APIs; AppKit file panels and `NSDocument`.
 
-- HIG file-management guidance
-- Apple document-based app patterns
-- SwiftUI file workflow APIs
-- AppKit file panels, document architecture, and Quick Look integration
-
-Emphasis:
-
-- standard file and document workflows instead of custom file UX
+Emphasis: standard file workflows, security-scoped bookmark balancing, and `NSFilePromiseProvider` for drag-out scenarios SwiftUI doesn't cover.
 
 ### `references/accessibility.md`
 
-Primary basis:
+Primary basis: Apple accessibility guidance for macOS; VoiceOver and accessibility API documentation.
 
-- Apple accessibility guidance for macOS
-- VoiceOver and accessibility API documentation
-
-Emphasis:
-
-- stable accessibility guidance centered on VoiceOver, keyboard navigation, and visual accessibility
+Emphasis: keyboard navigation completeness, the `TextField` focus-trap pattern, and explicit semantics for custom rows that aren't in `List`/`Table`.
 
 ### `references/swiftui-macos.md`
 
-Primary basis:
+Primary basis: SwiftUI scene, navigation, table, command, menu bar, file workflow, focus, drag, and toolbar APIs for macOS; Apple's own discussion of platform-variable placement and the documented constraints on `backgroundProminence`, `appearsActive`, `onMoveCommand`, and `onKeyPress`.
 
-- SwiftUI scene, navigation, table, command, menu bar, file workflow, and focus APIs for macOS
-
-Emphasis:
-
-- SwiftUI patterns that feel native on macOS rather than generic cross-platform usage
+Emphasis: native SwiftUI patterns plus an honest catalogue of the gaps Apple's documentation acknowledges, with concrete trigger signals for when to bridge.
 
 ### `references/appkit-and-bridging.md`
 
-Primary basis:
+Primary basis: AppKit documentation; `NSHostingView` / `NSHostingController` and representable bridging patterns; `NSDraggingSource`, `NSToolbarDelegate`, `NSMenuItemValidation`, and responder-chain documentation.
 
-- AppKit documentation
-- `NSHostingView`
-- standard representable bridging patterns
-
-Emphasis:
-
-- using AppKit deliberately and keeping the AppKit-SwiftUI bridge thin
+Emphasis: concrete trigger signals for when AppKit beats SwiftUI on Mac, with bridging rules and common pitfalls.
 
 ### `references/persistence-and-data.md`
 
-Primary basis:
+Primary basis: SwiftData documentation; document-based app guidance; Apple platform conventions for preferences vs documents vs relational app data; `@SceneStorage` and AppKit window restoration.
 
-- SwiftData documentation
-- document-based app guidance
-- Apple platform conventions for preferences vs documents vs relational app data
-
-Emphasis:
-
-- matching storage technology to the user’s mental model and app shape
+Emphasis: matching storage technology to the user's mental model, with Core Data still acknowledged as a valid choice.
 
 ### `references/platform-capabilities-distribution.md`
 
-Primary basis:
+Primary basis: sandboxing and entitlement guidance; ServiceManagement docs for login items; extension and Quick Look documentation; Apple distribution expectations for signed and notarized Mac apps.
 
-- sandboxing and entitlement guidance
-- ServiceManagement docs for login items
-- extension and Quick Look documentation
-- Apple distribution expectations for signed and notarized Mac apps
+Emphasis: capabilities, entitlements, signing, and distribution as one combined product-and-engineering decision; modern tooling (`notarytool`, `SMAppService`).
 
-Emphasis:
+## What this skill intentionally does not do
 
-- treating capabilities, entitlements, and distribution decisions as both UX and engineering concerns
-
-## What I intentionally removed
-
-During authoring, I discarded any concrete claims that I could not corroborate in Apple’s own documentation. That especially affected version-specific, newly announced, or overly specific platform assertions that named APIs or behaviors without clear support in Apple’s published materials.
+- Recommend SwiftUI workarounds for documented API gaps without naming the gap and the AppKit bridge
+- Make version-specific or newly announced platform claims without verification
+- Treat AppKit as legacy — it isn't; on Mac, it's still the right answer for some app shapes
+- Provide deeper coverage than the most recent macOS release that's been verified against Apple's published docs
 
 ## Install
 

--- a/macos-expert/SKILL.md
+++ b/macos-expert/SKILL.md
@@ -69,7 +69,7 @@ Shape B apps use `NSWindow`, `NSWindowController`, `NSToolbar`, `NSSplitViewCont
 When asked to build or review a macOS app, look for these signals and use them to pick the shape:
 
 | Signal | Implication |
-|---|---|
+| --- | --- |
 | "Mostly browsing content, with detail views" | Shape A |
 | "Settings-heavy utility" | Shape A |
 | "iPhone/iPad app we want on Mac too" | Shape A |

--- a/macos-expert/SKILL.md
+++ b/macos-expert/SKILL.md
@@ -5,7 +5,7 @@ description: Comprehensive modern macOS app development guidance grounded in App
 
 # macos-expert
 
-Use this skill to keep macOS work native, modern, and source-backed.
+Use this skill to keep macOS work native, modern, and source-backed. The skill is opinionated about when SwiftUI is enough, when AppKit is required, and when bridging is the right answer — because the wrong call here produces apps that look like Mac apps but feel like iPad apps in a window.
 
 ## When to use
 
@@ -23,7 +23,7 @@ Use this skill to keep macOS work native, modern, and source-backed.
 
 ## Recommended companion tools
 
-Using [Sosumi](https://sosumi.ai/) alongside this skill is highly recommended. Sosumi provides direct access to Apple Developer documentation and Human Interface Guidelines as Markdown, making it easy to verify APIs, symbols, and platform behavior referenced in this skill against current official sources.
+Using [Sosumi](https://sosumi.ai/) alongside this skill is highly recommended. Sosumi provides direct access to Apple Developer documentation and Human Interface Guidelines as Markdown, making it easy to verify APIs, symbols, and platform behavior referenced in this skill against current official sources. The verification workflow lives in `references/official-sources.md`.
 
 ## Source priority
 
@@ -32,39 +32,90 @@ Use sources in this order:
 1. Apple Human Interface Guidelines and Apple Developer documentation
 2. Reference files in this skill
 
-If a named API, symbol, modifier, entitlement, or platform behavior is uncertain, verify it against current official Apple documentation before presenting it as fact.
+If a named API, symbol, modifier, entitlement, or platform behavior is uncertain, verify it against current official Apple documentation **before** presenting it as fact. Pay particular attention to the "Available on" line on each API page — platform availability is the most common source of stale guidance. See `references/official-sources.md` for the full verification workflow.
 
-Start with `references/official-sources.md` if you need the verification workflow or the canonical Apple source map.
+## Two macOS app shapes — pick the right one before writing code
+
+The single highest-leverage decision when starting or reviewing a macOS app is choosing between two architectural shapes. Get this right and the rest of the work is straightforward. Get this wrong and you'll spend the project fighting the framework.
+
+### Shape A: SwiftUI-only Mac app
+
+A pure-SwiftUI Mac app is the right call when the product looks like:
+
+- A **content browser** (lists of items, detail panes, light forms — read-mostly, tap-to-drill)
+- A **utility / menu bar app** without a heavy main window
+- A **cross-platform port** where iOS is the primary target and macOS rides along via `#if os(macOS)`
+- A **document app** where the content area is your own custom drawing
+- An app whose interactions fit `NavigationSplitView` + `Table` + `.toolbar` + `.searchable` cleanly
+
+Shape A apps use `WindowGroup` / `Window` / `Settings` / `MenuBarExtra` scenes, `NavigationSplitView` for layout, and pure SwiftUI views inside. AppKit shows up only as `NSApplicationDelegate` plumbing for app-lifecycle and notification hooks.
+
+### Shape B: AppKit shell with surgically hosted SwiftUI
+
+An AppKit shell with hosted SwiftUI is the right call when the product needs:
+
+- A **power-user list/outline** with multi-selection drag rearrangement, custom row styling that depends on focus/emphasis, or a context-menu focus ring on the right-clicked row
+- **Drag-source lifecycle** beyond "drag started" — knowing when the session ended, where, with which operation, or producing file promises for Finder
+- **Keyboard-first workflows** mixing focused text fields with arrow-key navigation through results (Spotlight pattern), modal key handling alongside text input, or vim-style modes
+- **Deterministic toolbar layout** with explicit identifier order, allowed/default identifier lists, customization sheet, or tracking separators
+- **Rich text editing** beyond plain `TextEditor`
+- **Custom window chrome** (title bar accessory views, transparent windows, etc.) or detailed responder-chain control
+- **High-volume tables** beyond what `Table` performs at
+
+Shape B apps use `NSWindow`, `NSWindowController`, `NSToolbar`, `NSSplitViewController`, `NSTableView` / `NSOutlineView` for the parts that need power-user behavior, and `NSHostingView` / `NSHostingController` to embed SwiftUI for panes that don't (settings forms, account configuration, mostly-static content). NetNewsWire is a textbook Shape B app.
+
+### Triage signals — pattern-match the request
+
+When asked to build or review a macOS app, look for these signals and use them to pick the shape:
+
+| Signal | Implication |
+|---|---|
+| "Mostly browsing content, with detail views" | Shape A |
+| "Settings-heavy utility" | Shape A |
+| "iPhone/iPad app we want on Mac too" | Shape A |
+| "Menu bar app" | Shape A |
+| "Power-user list/outline with multi-select drag" | Shape B |
+| "Drag must know when it was cancelled" | Shape B |
+| "Search with arrow keys nav through results" | Shape B |
+| "Three-pane layout with deterministic toolbar" | Shape B |
+| "Rich text editor with attributed runs" | Shape B |
+| "Existing AppKit app adopting SwiftUI" | Shape B |
+
+Many real apps mix shapes — a Shape B main window can have Shape A preferences and onboarding. The wrong call is choosing Shape A when the product needs Shape B affordances and then fighting SwiftUI's gaps.
 
 ## Core workflow
 
 1. Classify the task: design review, implementation, migration, bug fix, architecture, or distribution
 2. Identify the minimum macOS version, primary UI framework, and whether the app is document-based, window-based, or menu-bar-first
-3. Load the reference files that match the task instead of reading everything
-4. Prefer standard macOS behaviors before inventing custom UI or app flow
-5. Call out version constraints, fallback paths, and trade-offs explicitly
-6. Distinguish design guidance from API guidance
+3. Apply the Shape A vs Shape B triage above
+4. Load the reference files that match the task instead of reading everything
+5. Prefer standard macOS behaviors before inventing custom UI or app flow
+6. Call out version constraints, fallback paths, and trade-offs explicitly
+7. Distinguish design guidance from API guidance
+8. When recommending an API, verify availability against Apple docs before claiming it exists on the target platform/version
 
 ## Load the right references
 
-- Read `references/designing-for-macos.md` for macOS-first product and UX decisions
+- Read `references/designing-for-macos.md` for macOS-first product and UX decisions, including concrete "iPad-in-a-window" anti-pattern signals
   - *Triggers: design review, native feel, platform expectations, Mac vs iPad patterns, layout density*
-- Read `references/windows-navigation.md` for windows, toolbars, sidebars, sheets, popovers, inspectors, and full-screen behavior
+- Read `references/windows-navigation.md` for windows, toolbars, sidebars, sheets, popovers, inspectors, and full-screen behavior — including the SwiftUI toolbar determinism caveat
   - *Triggers: WindowGroup, DocumentGroup, NavigationSplitView, NSWindow, NSToolbar, NSSplitViewController, toolbar, sidebar, inspector, sheet, popover, full-screen, window resize*
-- Read `references/menus-commands-input.md` for menu bar structure, commands, shortcuts, undo/redo, clipboard, pointer, keyboard, and drag-and-drop expectations
-  - *Triggers: menu bar, NSMenu, .commands, CommandGroup, keyboard shortcut, ⌘, undo, redo, copy, paste, context menu, drag and drop, .draggable, .dropDestination, NSDraggingSource, Dock menu*
+- Read `references/menus-commands-input.md` for menu bar structure, commands, shortcuts, undo/redo, clipboard, pointer, keyboard, and drag-and-drop — including SwiftUI keyboard and drag-lifecycle gaps
+  - *Triggers: menu bar, NSMenu, .commands, CommandGroup, keyboard shortcut, ⌘, undo, redo, copy, paste, context menu, drag and drop, .draggable, .dropDestination, NSDraggingSource, Dock menu, onMoveCommand, onKeyPress*
 - Read `references/file-management-documents.md` for open/save/import/export, document workflows, file access, Quick Look, and Finder-facing behavior
-  - *Triggers: DocumentGroup, FileDocument, ReferenceFileDocument, NSDocument, NSOpenPanel, NSSavePanel, .fileImporter, .fileExporter, UTType, Quick Look, Finder, open panel, save panel, recent documents*
-- Read `references/accessibility.md` for VoiceOver, keyboard navigation, focus, contrast, motion, and testing
+  - *Triggers: DocumentGroup, FileDocument, ReferenceFileDocument, NSDocument, NSOpenPanel, NSSavePanel, .fileImporter, .fileExporter, UTType, Quick Look, Finder, open panel, save panel, recent documents, file promises, NSFilePromiseProvider*
+- Read `references/accessibility.md` for VoiceOver, keyboard navigation, focus, contrast, motion, and testing — including TextField focus-trap patterns
   - *Triggers: VoiceOver, accessibility, .accessibilityLabel, NSAccessibility, focus, keyboard navigation, contrast, reduce motion, assistive technology*
-- Read `references/swiftui-macos.md` for modern SwiftUI patterns specific to macOS
-  - *Triggers: SwiftUI on macOS, NavigationSplitView, Table, MenuBarExtra, Settings, .searchable, @FocusState, Observation, scene, SwiftUI commands, SwiftUI toolbar*
-- Read `references/appkit-and-bridging.md` for AppKit-heavy work and AppKit-SwiftUI integration
-  - *Triggers: AppKit, NSHostingView, NSHostingController, NSViewRepresentable, NSViewControllerRepresentable, coordinator, bridging, responder chain, NSTableView, NSOutlineView*
+- Read `references/swiftui-macos.md` for modern SwiftUI patterns specific to macOS — and the documented gaps that should drive bridging decisions
+  - *Triggers: SwiftUI on macOS, NavigationSplitView, Table, MenuBarExtra, Settings, .searchable, @FocusState, Observation, scene, SwiftUI commands, SwiftUI toolbar, .draggable, .contextMenu*
+- Read `references/appkit-and-bridging.md` for AppKit-heavy work, AppKit-SwiftUI integration, and concrete trigger signals for choosing AppKit
+  - *Triggers: AppKit, NSHostingView, NSHostingController, NSViewRepresentable, NSViewControllerRepresentable, coordinator, bridging, responder chain, NSTableView, NSOutlineView, NSDraggingSource, NSToolbarDelegate*
 - Read `references/persistence-and-data.md` for SwiftData, Core Data, document data, settings, and migration choices
-  - *Triggers: SwiftData, Core Data, @Query, ModelActor, FetchDescriptor, @AppStorage, UserDefaults, persistence, migration, schema, database*
+  - *Triggers: SwiftData, Core Data, @Query, ModelActor, FetchDescriptor, @AppStorage, @SceneStorage, UserDefaults, persistence, migration, schema, database, CloudKit*
 - Read `references/platform-capabilities-distribution.md` for sandboxing, bookmarks, extensions, menu bar apps, login items, signing, notarization, and distribution
-  - *Triggers: sandbox, entitlement, security-scoped bookmark, App Group, SMAppService, login item, MenuBarExtra, NSStatusItem, extension, Finder Sync, XPC, notarization, Developer ID, Hardened Runtime, Mac App Store, distribution*
+  - *Triggers: sandbox, entitlement, security-scoped bookmark, App Group, SMAppService, login item, MenuBarExtra, NSStatusItem, extension, Finder Sync, XPC, notarization, Developer ID, Hardened Runtime, Mac App Store, distribution, notarytool*
+- Read `references/official-sources.md` for the verification workflow and the canonical Apple source map
+  - *Triggers: any time you're about to claim an API exists or recommend a modifier; any availability-related question*
 
 ## Non-negotiables
 
@@ -74,6 +125,7 @@ Start with `references/official-sources.md` if you need the verification workflo
 - Treat keyboard support, context menus, drag and drop, and undo/redo as core Mac affordances
 - If custom UI replaces a standard control, preserve discoverability, keyboard support, and accessibility semantics
 - Avoid version-specific or newly announced platform claims unless verified against current official docs
+- Don't recommend SwiftUI primitives for affordances they don't fully support (custom-row selection emphasis, drag lifecycle, deterministic toolbar layout, focused-TextField key interception) without acknowledging the gap and offering the AppKit bridge
 
 ## Common anti-patterns
 
@@ -84,10 +136,14 @@ Start with `references/official-sources.md` if you need the verification workflo
 - Building custom file pickers instead of using system open/save panels
 - Treating drag and drop as optional in workflows where files or lists are central
 - Importing iOS tab bars, bottom sheets, or navigation stacks where Mac-native sidebars, inspectors, or split views belong
+- Choosing Shape A when the product needs Shape B affordances and ending up with custom workarounds for selection emphasis, drag lifecycle, or toolbar layout
+- Recommending an API without checking its "Available on" line — the most common source of broken cross-platform code
 
 ## Response expectations
 
-- For reviews, explain what is non-native, why it matters on macOS, and the simplest native fix
+- For reviews, explain what is non-native, why it matters on macOS, and the simplest native fix. Be specific — name the affordance, the API, and the bridge if needed
 - For implementation guidance, prefer native Apple APIs over third-party abstractions unless there is a strong reason not to
-- For architecture questions, keep the answer proportional to app size and deployment target
+- For architecture questions, lead with the Shape A vs Shape B triage; keep the answer proportional to app size and deployment target
 - For file and sandbox questions, address both user experience and entitlement/security implications
+- When SwiftUI doesn't do what's asked, say so directly and name the AppKit alternative — don't invent workarounds for documented gaps
+- Cite Apple documentation specifically when a claim is non-obvious (especially "Available on" lines and Discussion sections)

--- a/macos-expert/references/accessibility.md
+++ b/macos-expert/references/accessibility.md
@@ -1,83 +1,103 @@
 # Accessibility on macOS
 
-Accessibility is part of correctness on macOS, not an optional polish pass.
+Accessibility is part of correctness on macOS, not an optional polish pass. The Mac platform's accessibility expectations are higher than iOS — VoiceOver and Full Keyboard Access users expect every action to be reachable without a pointer.
 
 ## Non-negotiables
 
 - Every interactive element has a clear accessible name
-- Keyboard-only navigation can complete the app’s primary workflows
+- Keyboard-only navigation can complete the app's primary workflows
 - Focus order is logical and visible
 - Information is not conveyed by color alone
 - Motion-heavy UI respects reduced-motion settings
+- Custom controls expose the correct role and state, not a generic "button" fallback
 
 ## VoiceOver
 
 - Prefer standard controls first; they carry strong semantics automatically
-- Add labels, values, hints, and roles only where the defaults are incomplete
-- Combine child elements when a row or card should read as one unit
-- Hide decorative visuals from the accessibility tree
-- For custom controls, provide the correct role and adjustable/action semantics
+- Add labels, values, hints, and roles only where defaults are incomplete
+- Combine child elements when a row or card should read as one unit (`.accessibilityElement(children: .combine)`)
+- Hide decorative visuals from the accessibility tree (`.accessibilityHidden(true)`)
+- For custom controls, provide the correct role, value, and adjustable/action semantics
 
 ## Keyboard and focus
 
-- Support tab navigation through forms and primary controls
+- Support tab navigation through forms and primary controls (Full Keyboard Access)
 - Make list, table, sidebar, and detail workflows practical from the keyboard
 - Expose menu commands and shortcuts for core actions
-- Keep focus stable during updates, inserts, and view transitions
+- Keep focus stable during updates, inserts, and view transitions; don't yank focus mid-edit
+- Test with Tab, Shift-Tab, arrow keys, Return, Space, and Esc in every primary flow
+
+### Focus traps to watch for
+
+- A `TextField` with focus consumes arrow keys for cursor movement. If the surrounding workflow expects arrow keys to navigate a result list while the field is focused (Spotlight pattern), SwiftUI alone won't deliver it cleanly. `onKeyPress(_:action:)` returning `.ignored` is partial — see `menus-commands-input.md` and `swiftui-macos.md` for the bridging signal
+- Custom focus rings drawn over views may suppress the system focus ring; preserve the system one or replicate it pixel-accurately
+- Modal sheets and popovers must restore focus to the previous control on dismissal
 
 ## Tables, lists, and data-dense UI
 
-- Use `Table`, `List`, `NSTableView`, or `NSOutlineView` semantics instead of free-form grids when the content is tabular
-- Make row purpose, selection state, and activation behavior obvious
-- Avoid custom list rows that look rich visually but read poorly with assistive technology
+- Use `Table`, `List`, `NSTableView`, or `NSOutlineView` semantics instead of free-form grids when the content is tabular — these give VoiceOver row/column context for free
+- Custom rows built in `ScrollView` + `LazyVStack` lose row semantics; you'll need explicit `.accessibilityElement(children:)`, row position via `.accessibilityValue`, and rotor support if the list is large
+- Make row purpose, selection state, and activation behavior obvious to assistive tech
+- Avoid custom list rows that look rich visually but read poorly with VoiceOver
 
 ## Visual accessibility
 
-- Use semantic colors where possible
+- Use semantic colors where possible (`Color.primary`, `.secondary`, `.accentColor`, `.red` only for genuinely red things)
 - Meet at least WCAG AA contrast targets for text and critical UI
-- Respect increased-contrast and differentiate-without-color settings
+- Respect Increase Contrast and Differentiate Without Color settings (`@Environment(\.colorSchemeContrast)`, `@Environment(\.accessibilityDifferentiateWithoutColor)`)
 - Ensure hover-only affordances have an always-visible fallback for keyboard or assistive-tech users
+- Inactive-window styling should not push contrast below threshold
 
 ## Motion and animation
 
-- Respect reduce-motion preferences
+- Respect Reduce Motion (`@Environment(\.accessibilityReduceMotion)`)
 - Prefer short, informative transitions over decorative motion
-- Use non-motion alternatives like state, outline, icon, or text changes when necessary
+- Use non-motion alternatives like state changes, outlines, icons, or text when motion is reduced
+- Auto-play behavior must be disabled when Reduce Motion is on
 
 ## SwiftUI tools
 
 - `.accessibilityLabel`, `.accessibilityValue`, `.accessibilityHint`
 - `.accessibilityElement(children:)`
-- `.accessibilityAddTraits`
+- `.accessibilityAddTraits`, `.accessibilityRemoveTraits`
 - `.accessibilityHidden`
-- `.accessibilityAdjustableAction`
-- `@FocusState`
+- `.accessibilityAdjustableAction`, `.accessibilityAction`
+- `.accessibilityRotor` for grouped navigation in long content
+- `@FocusState`, `.focusable(_:)`, `.focused(_:)`
+- `@Environment(\.accessibilityReduceMotion)`, `\.accessibilityDifferentiateWithoutColor`, `\.accessibilityReduceTransparency`, `\.accessibilityVoiceOverEnabled`
 
 ## AppKit tools
 
-- `NSAccessibility` overrides and setters
-- `nextKeyView`
-- menu validation and responder-chain actions
+- `NSAccessibility` overrides and setters for custom views (`accessibilityRole`, `accessibilityLabel`, `accessibilityValue`, `accessibilityChildren`)
+- `NSAccessibilityElement` for non-view accessibility nodes
+- `nextKeyView` / `previousKeyView` to control tab order
+- Menu validation and responder-chain actions for keyboard-driven command coverage
 - Accessibility Inspector and VoiceOver testing
 
 ## Test like this
 
-- Turn on VoiceOver and walk the primary workflows
-- Test the app with keyboard only
-- Increase text size and contrast settings
-- Check common empty, error, loading, and selection states
+- Turn on VoiceOver and walk every primary workflow start-to-finish
+- Test with keyboard only — disable mouse / trackpad mentally for a session
+- Increase text size and contrast in System Settings
+- Enable Reduce Motion and verify the app degrades gracefully
+- Check empty, error, loading, and selection states with VoiceOver
+- Use the Accessibility Inspector's audit feature to catch missing labels and contrast issues
+- Test sidebar / timeline / detail patterns specifically — Mac users with Full Keyboard Access live here
 
 ## Review checklist
 
-- Labels, values, hints, and roles are complete
-- Primary workflows are keyboard-complete
-- Focus does not jump unpredictably
+- Labels, values, hints, and roles are complete on custom controls
+- Primary workflows are keyboard-complete with no dead ends
+- Focus does not jump unpredictably or get trapped in `TextField`s
 - Complex rows, custom controls, and tables remain understandable to VoiceOver
-- Contrast and motion settings are respected
+- Custom containers (`ScrollView` + `LazyVStack`) have explicit row semantics
+- Contrast, motion, and transparency settings are respected
+- AppKit views in a SwiftUI shell have explicit `NSAccessibility` setup
+- Menu bar coverage gives every action a keyboard-reachable path
 
 ## Pair this file with
 
 - `designing-for-macos.md` for macOS interaction expectations that affect accessibility
-- `menus-commands-input.md` for keyboard shortcuts and command coverage
-- `swiftui-macos.md` for SwiftUI accessibility modifiers and focus APIs
+- `menus-commands-input.md` for keyboard shortcuts, command coverage, and the TextField focus-trap discussion
+- `swiftui-macos.md` for SwiftUI accessibility modifiers and the focus/TextField gap
 - `appkit-and-bridging.md` for AppKit accessibility overrides and bridging concerns

--- a/macos-expert/references/appkit-and-bridging.md
+++ b/macos-expert/references/appkit-and-bridging.md
@@ -1,60 +1,152 @@
 # AppKit and AppKit-SwiftUI bridging
 
-AppKit is still the right answer for some macOS problems. Use it deliberately, and keep the bridge thin.
+AppKit is alive, supported, and still the right answer for some macOS app shapes. Use it deliberately. Keep the bridge thin.
 
-## Prefer AppKit when
+This file covers (1) when AppKit beats SwiftUI on Mac, (2) how to bridge in either direction, and (3) the responder-chain and menu-validation patterns SwiftUI doesn't replicate.
 
-- text editing goes beyond basic text fields or plain text editors
-- tables, outlines, or collection views need mature desktop behavior or high scale
-- you need detailed window, responder-chain, or menu control
-- you are migrating an existing AppKit app incrementally
-- SwiftUI lacks a native capability or imposes unacceptable performance or lifecycle trade-offs
+## Prefer AppKit when — concrete trigger signals
+
+Reach for AppKit (either as the app shell or for specific subsystems) when any of these are true. These are the signals SwiftUI's primitives don't reach.
+
+### List/outline behavior
+
+- You need a context menu focus ring on the right-clicked row even when it isn't selected — `NSTableView` and `NSOutlineView` do this automatically; SwiftUI's `List` does it but you can't customize, and `ScrollView`/`LazyVStack` don't do it at all
+- You need de-emphasized selection styling in **custom row layouts** (not `List`/`Table`) — `NSTableRowView.isEmphasized` and `NSView.BackgroundStyle` give you this; SwiftUI's `\.backgroundProminence` only fires inside `List`/`Table`
+- You need multi-row drag rearrangement with live drop indicators
+- You need outline disclosure with custom expand/collapse animation or styling
+- Row count is large (tens of thousands+) and `Table` performance is unacceptable
+- You need column customization persisted via standard menus, with view-based tracking separators
+
+### Drag and drop
+
+- You need `draggingSession(_:endedAt:operation:)` to react to cancellation, drop-outside-window, or final operation result
+- You need `draggingSession(_:movedTo:)` to update UI during the drag
+- You need `NSFilePromiseProvider` for lazy file generation on drop
+- You need per-item drag images that differ from the source view rendering
+- You need `NSDraggingItem.imageComponentsProvider` for multi-component drag previews
+
+### Keyboard and responder chain
+
+- You need a focused text field to coexist with arrow-key navigation through results (Spotlight pattern)
+- You need `performKeyEquivalent(with:)` participation through the responder chain
+- You need menu validation via `NSMenuItemValidation` / `validateUserInterfaceItem(_:)` so menu state reflects responder context
+- You need precise key-event interception on non-focused views via `NSResponder.keyDown(with:)` overrides
+- You need vim-style modal key handling, chord shortcuts, or other custom key models
+
+### Toolbar
+
+- You need deterministic placement, an explicit allowed/default identifier list (`NSToolbarDelegate.toolbarAllowedItemIdentifiers`, `toolbarDefaultItemIdentifiers`), and the standard toolbar customization sheet
+- You need a toolbar tracking separator anchored to a split view divider
+- You need search-field, segmented-control, or other specialized toolbar item identifiers without the SwiftUI ones
+- You need `NSToolbarItemGroup` with subitem behaviors
+
+### Windows
+
+- You need custom title bar accessory view controllers
+- You need a transparent or custom-shaped window
+- You need precise window resize behavior, content-aspect-ratio constraints, or `NSWindow.collectionBehavior` flags SwiftUI doesn't expose
+- You need to participate in the window-tabs system explicitly
+- You need `NSPanel` semantics for utility windows
+- You need to drive multiple windows from a single controller with shared state, fully
+
+### Text editing
+
+- You need attributed-run editing, custom layout managers, paragraph attributes, find/replace UI integration, ruler bars, or any of `NSTextView`'s editing surface beyond plain text
+- You need to drive `NSTextStorage` for syntax highlighting or LSP integration
+
+### Document architecture
+
+- You're migrating from an existing `NSDocument`-based app
+- You need autosave, version browser, document tabs, or `NSDocumentController` behavior `DocumentGroup` doesn't expose
+
+If none of these apply, SwiftUI is probably fine. See `swiftui-macos.md`.
 
 ## Bridge directions
 
-### AppKit hosting SwiftUI
+### AppKit hosting SwiftUI (recommended for Mac-assed apps)
 
 Use:
 
-- `NSHostingView`
-- `NSHostingController`
+- `NSHostingView` to embed a SwiftUI view inside an AppKit view hierarchy
+- `NSHostingController` when you want a view controller wrapping a SwiftUI root
 
-This is the best default for incrementally adopting SwiftUI inside an AppKit app.
+This is the right default for:
+
+- Existing AppKit apps adopting SwiftUI incrementally
+- New apps where the shell is AppKit (windows, toolbars, sidebar/timeline/detail) and panes inside the shell are SwiftUI (forms, settings, mostly-static content)
+
+The NetNewsWire pattern: AppKit `NSWindowController`, `NSToolbar`, `NSOutlineView`, `NSTableView` for the main window; SwiftUI views hosted inside the accounts pane and similar leaf surfaces.
 
 ### SwiftUI hosting AppKit
 
 Use:
 
-- `NSViewRepresentable`
-- `NSViewControllerRepresentable`
+- `NSViewRepresentable` to wrap a single AppKit view
+- `NSViewControllerRepresentable` to wrap a controller-backed view
 
-This is the best default when SwiftUI is the shell but specific controls still need AppKit.
+This is the right default for:
+
+- Cross-platform apps that are SwiftUI-first but need a specific AppKit control (rich text editor, web view, professional table)
+- Embedding AppKit-only system views (`NSPathControl`, `NSColorWell` historically, `NSVisualEffectView`)
+
+Watch the seams: `Coordinator` is where most bugs live. Make it a class with explicit lifecycle, hold weak references where the AppKit view is the strong owner, and clean up observers, delegates, and Combine subscriptions in `dismantleNSView` / `dismantleNSViewController`.
 
 ## Bridging rules
 
-- Keep the bridge boundary narrow; do not hide an entire architecture problem inside representables
+- Keep the bridge boundary narrow. Do not hide an architectural decision inside a representable
 - Put durable mutable state in observable models or controllers, not in transient view structs
-- Update coordinators carefully so they do not hold stale references
-- Clean up observers, delegates, tasks, and notifications in dismantle paths
-- Let SwiftUI manage layout where possible instead of hard-coding frames from AppKit setup code
+- Update coordinators on `updateNSView(_:context:)` carefully; don't reapply state that hasn't changed
+- Clean up observers, KVO, delegates, tasks, and notifications in dismantle paths
+- Let SwiftUI manage layout where possible; avoid hard-coding frames inside AppKit setup code
+- Don't bridge for the sake of it. If the SwiftUI view in question fits SwiftUI cleanly, ship it; if the AppKit view fits AppKit cleanly, ship it; bridge only at the seam
+
+## Responder chain and menu validation
+
+This is a SwiftUI gap that's easy to miss. AppKit's responder chain is how Mac apps deliver commands to the right object based on focus, and it's how menu items know when to enable, disable, change title, or show a checkmark.
+
+- First responder receives the action; if it doesn't handle, the action walks up the chain through superviews, view controllers, the window, the window controller, the app delegate, the application
+- `NSMenuItem.isEnabled` is driven by `NSMenuItemValidation.validateMenuItem(_:)` or `NSUserInterfaceValidations.validateUserInterfaceItem(_:)` on whichever responder claims it
+- Standard items (Cut/Copy/Paste, Undo/Redo, Find, etc.) walk the chain so the focused control gets first crack
+
+In SwiftUI, `.commands` plus `Button(action:)` partially substitutes, but commands are global to the scene rather than focus-aware. If menu state must reflect the focused view, AppKit's responder chain is the right primitive.
 
 ## AppKit-native guidance
 
-- Use `NSToolbar`, `NSSplitViewController`, `NSTableView`, `NSOutlineView`, `NSVisualEffectView`, `NSOpenPanel`, and `NSSavePanel` before building custom replacements
-- Use the responder chain and menu validation for command behavior
-- Preserve standard selection, editing, and keyboard behaviors
+Prefer the standard AppKit primitives before building custom replacements:
+
+- `NSToolbar` and `NSToolbarItem` (including `NSSearchToolbarItem`, `NSSharingServicePickerToolbarItem`, `NSTrackingSeparatorToolbarItem`) over custom toolbars
+- `NSSplitViewController` over hand-rolled split views
+- `NSTableView` and `NSOutlineView` over custom row containers
+- `NSCollectionView` for grid/icon layouts
+- `NSVisualEffectView` for vibrancy
+- `NSOpenPanel` and `NSSavePanel` for file dialogs
+- `NSAlert` for alerts; `NSPanel` for utility windows
+- `NSPasteboard`, `NSPasteboardItem`, `NSPasteboardWriting`, `NSPasteboardReading` for clipboard and drag payloads
+
+Preserve standard selection, editing, and keyboard behaviors — Mac users notice when these don't work the system way.
+
+## Common AppKit pitfalls
+
+- Forgetting to set `delegate` and `dataSource` after waking from a nib or programmatic init
+- KVO observers not removed before deallocation
+- `NSWindowController` retained nowhere — windows can vanish under you
+- Auto layout fights with `setFrame:`/`autoresizingMask`-based sizing; pick one model per view
+- `NSTableCellView` reuse races: configure cells defensively in `tableView(_:viewFor:row:)`
+- Forgetting `automaticallyManagesSubscriptions` semantics on Combine bridges
+- Hosting a SwiftUI view inside AppKit and assuming it'll resize correctly without an `NSHostingView` sizing pass
 
 ## Review checklist
 
-- AppKit is used for a concrete reason, not just habit
-- Hosted SwiftUI and wrapped AppKit views have clear ownership and state flow
-- Coordinators, delegates, and notifications are cleaned up correctly
-- Layout and resizing remain stable
-- Standard AppKit controls are preferred over unnecessary custom widgets
+- AppKit is used for a concrete trigger signal, not because of habit or aesthetic preference
+- Hosted SwiftUI and wrapped AppKit views have clear ownership and explicit state flow
+- Coordinators, delegates, KVO, and notifications are cleaned up in dismantle paths
+- Layout and resizing are stable across resize and full-screen
+- Standard AppKit controls are preferred over custom widgets
+- Responder chain and menu validation are used where focus-aware command behavior matters
 
 ## Pair this file with
 
-- `swiftui-macos.md` for SwiftUI-first patterns and when SwiftUI is enough
+- `swiftui-macos.md` for SwiftUI-first patterns, what works, and the documented gaps
 - `windows-navigation.md` for AppKit window, toolbar, and split-view details
 - `menus-commands-input.md` for responder chain, menu validation, and drag-and-drop
 - `accessibility.md` for AppKit accessibility overrides and testing

--- a/macos-expert/references/designing-for-macos.md
+++ b/macos-expert/references/designing-for-macos.md
@@ -1,24 +1,42 @@
 # Designing for macOS
 
-This reference turns Apple’s macOS HIG into a practical review and implementation lens.
+This reference turns Apple's macOS HIG into a practical review and implementation lens.
 
 ## Core macOS principles
 
 - Design for **keyboard, mouse, trackpad, and menu bar**, not just direct-manipulation touch metaphors
-- Treat **windows** as first-class workspaces
-- Expect users to multitask across multiple windows, apps, and displays
+- Treat **windows** as first-class workspaces — users multitask across multiple windows, apps, displays, and Spaces
 - Use the **menu bar, toolbars, sidebars, inspectors, context menus, drag and drop, and clipboard** as part of the core experience
 - Favor **clarity, efficiency, and information density** over oversized mobile-style layouts
-- Respect the system’s appearance, typography, focus model, accent color, and accessibility settings
+- Respect the system's appearance, typography, focus model, accent color, sidebar styling, and accessibility settings
+- Mac users expect every command to live in a menu, every menu item to have a stable location, and every primary action to have a keyboard path
 
-## What “native on macOS” usually means
+## What "native on macOS" usually means
 
-- The app has a sensible menu structure and keyboard shortcuts
-- Important actions are discoverable from menus, toolbars, or contextual UI
-- Windows resize well and preserve useful state
+- The app has a sensible menu structure with all commands present, including standard items
+- Important actions are discoverable from menus, toolbars, or contextual UI — not only from one
+- Windows resize well and preserve useful state across launches
 - Sidebar/list/detail layouts use standard column behavior instead of custom chrome
 - Dialogs, sheets, popovers, and panels are used for the right level of interruption
 - Users can move data with copy/paste, drag and drop, import/export, and open/save flows
+- Inactive windows desaturate; selection emphasis behaves correctly when focus moves
+- Drag and drop has lifecycle (sources know when their drag was cancelled)
+- Right-click reveals context menus with the right items for the clicked target
+
+## "iPad app in a window" signals
+
+When reviewing a Mac app, these are the concrete signs that an iOS-shaped product was shipped on Mac without translation. Each is worth flagging:
+
+- The window has a tab bar at the bottom instead of a sidebar at the leading edge
+- Important actions live only in floating buttons or only in a single overflow menu — no menu bar coverage
+- No keyboard shortcuts beyond what `keyboardShortcut(_:)` auto-provides on a button
+- The window can't resize meaningfully, or has no minimum / maximum / ideal size
+- Right-click does nothing or shows a menu copied from iOS that lacks Mac conventions (Open, Show in Finder, Copy, Reveal, etc.)
+- Lists don't respond to arrow keys, Return, or Space
+- No undo, no copy/paste plumbing, no drag and drop on file-shaped data
+- "Settings" lives inside a navigation stack instead of in `Settings` (⌘,)
+- Fonts, paddings, and tap targets are touch-sized rather than mouse-sized
+- The app uses iOS-style sheet presentation for tasks Mac would model as a panel, sheet, or inspector
 
 ## Review heuristics
 
@@ -29,25 +47,55 @@ When reviewing a macOS app, ask:
 3. Does the app support multiple windows or document flows where users would expect them?
 4. Are advanced tasks efficient with keyboard and pointer input?
 5. Does the app cooperate with Finder, file dialogs, and standard system services?
+6. Do inactive windows and de-emphasized selections look right when focus moves?
+7. Does drag and drop have correct lifecycle, or does it leave the UI in inconsistent states on cancel?
 
 ## Common anti-patterns
 
-- Hiding core actions behind a single overflow menu
+- Hiding core actions behind a single overflow menu instead of using the menu bar and toolbar
 - Replacing normal window chrome or toolbar behavior without a strong reason
 - Giant touch-sized controls that waste space on desktop
 - No keyboard navigation, no shortcuts, or no context menus
 - Treating drag and drop as optional in workflows where files or lists are central
 - Building custom file pickers instead of using system open/save panels
+- Using SwiftUI primitives for affordances they don't fully support (custom-row selection emphasis, drag lifecycle, menu-state observation, deterministic toolbar layout) without bridging
+- Tab bars where a sidebar belongs
+- iOS-style "back" navigation in a window that should use real navigation columns
 
 ## What to prefer by default
 
 - `NavigationSplitView`, `Table`, `Form`, system toolbars, standard alerts and confirmation dialogs in SwiftUI
-- `NSWindow`, `NSToolbar`, `NSSplitViewController`, `NSTableView`, `NSOpenPanel`, and `NSSavePanel` in AppKit
+- `NSWindow`, `NSToolbar`, `NSSplitViewController`, `NSTableView`, `NSOutlineView`, `NSOpenPanel`, `NSSavePanel` in AppKit
 - Standard macOS commands for About, Settings, Hide, Quit, Window management, Find, Undo/Redo, Copy/Paste
+- The Mac convention of disabling, not hiding, temporarily unavailable menu items
+
+## When SwiftUI alone is enough
+
+A pure-SwiftUI Mac app is the right call when:
+
+- The product is a content browser, settings-heavy utility, or cross-platform port whose iOS shape carries over reasonably
+- Lists are mostly read-only or simple-edit; no drag rearrangement with lifecycle, no custom selection emphasis, no context-menu focus styling
+- Toolbars are simple enough that platform-variable placement is fine
+- Keyboard handling is limited to standard shortcuts, not search-while-arrow-nav patterns
+- One main `Window` or `WindowGroup`, optional `Settings`, optional `MenuBarExtra`
+
+## When AppKit is the right shell
+
+Use an AppKit shell with surgically hosted SwiftUI when:
+
+- The main window is a power-user list/outline/detail layout (NetNewsWire shape, Mail shape, source-list-driven)
+- Custom selection emphasis, context-menu focus rings, or drag rearrangement with live indicators are required
+- Drag-source lifecycle matters operationally (cancel handling, file promises, drop-outside-window)
+- Toolbars need deterministic placement, customization sheets, tracking separators, or specialized item identifiers
+- Keyboard handling extends to focused-text-field-with-arrow-nav patterns, modal modes, or custom responder participation
+
+The "AppKit shell, hosted SwiftUI inside" pattern (`NSHostingView` / `NSHostingController`) gets you the best of both: AppKit owns the parts SwiftUI is bad at, SwiftUI owns the parts it's good at.
 
 ## Pair this file with
 
-- `windows-navigation.md` for layout and scene structure
-- `menus-commands-input.md` for shortcuts, commands, pointer, and drag-and-drop behavior
+- `windows-navigation.md` for layout and scene structure, plus toolbar determinism caveats
+- `menus-commands-input.md` for shortcuts, commands, pointer, drag-and-drop, and SwiftUI keyboard gaps
 - `file-management-documents.md` for file-centric workflows
 - `accessibility.md` for inclusive interaction requirements
+- `swiftui-macos.md` for SwiftUI patterns and the documented gaps
+- `appkit-and-bridging.md` for AppKit shell patterns and bridging

--- a/macos-expert/references/file-management-documents.md
+++ b/macos-expert/references/file-management-documents.md
@@ -1,76 +1,88 @@
 # File management and document workflows
 
-File handling is a core Mac experience. Prefer standard system flows over custom UI.
+File handling is a core Mac experience. Prefer standard system flows over custom UI, and match the data model to how the user thinks about files.
 
 ## Start with the right model
 
-- Use **document-based architecture** when users primarily create, open, edit, save, duplicate, and compare files
-- Use **app-managed storage** when documents are secondary and the app owns the data model
-- Use **settings storage** only for preferences, not user content
+- **Document-based architecture** when users primarily create, open, edit, save, duplicate, and compare files
+- **App-managed storage** when documents are secondary and the app owns the data model (mail, RSS, IM, photo libraries)
+- **Settings storage** only for preferences, not user content
+
+If the user says "open" or "save" or thinks of their work as a discrete file in Finder, the workflow is document-shaped. If the user says "library" or "list" and thinks of items as living inside the app, it's app-managed.
 
 ## Preferred tools
 
 ### SwiftUI
 
-- `DocumentGroup`
-- `FileDocument` or `ReferenceFileDocument`
-- `.fileImporter`
-- `.fileExporter`
-- `.fileMover`
-- `UTType`
+- `DocumentGroup` — scene type for file-document apps
+- `FileDocument` — value-typed documents with snapshot semantics (good for plain data)
+- `ReferenceFileDocument` — class-typed documents when reference semantics are required
+- `.fileImporter`, `.fileExporter`, `.fileMover` — system file panels in modal SwiftUI form
+- `UTType` — uniform type identifiers for declared content types
 
 ### AppKit
 
-- `NSDocument`
-- `NSOpenPanel`
-- `NSSavePanel`
-- `NSFilePromiseProvider` where exported files are created lazily
-- Quick Look integrations when custom file types need previews
+- `NSDocument` and `NSDocumentController` — full document architecture with autosave, version browser, recents
+- `NSOpenPanel`, `NSSavePanel` — system file panels with full delegate control
+- `NSFilePromiseProvider` and `NSFilePromiseReceiver` — lazy file generation for drag-out scenarios (no SwiftUI equivalent)
+- Quick Look integrations (`QLPreviewPanel`, `QLPreviewItem`) for custom file types
 
 ## Open, save, import, export
 
-- Use system open/save panels instead of custom pickers
-- Separate **import/export** from **open/save** when the user’s model actually differs
+- Use system open/save panels instead of custom pickers — users expect Finder-shaped chooser UI
+- Separate **import/export** from **open/save** when the user's mental model differs (export converts; save persists the working file)
 - If the app works on user files, preserve their file names, types, and locations where possible
-- If import is central, support file drag-and-drop as well as menu and toolbar entry points
+- If import is central, support file drag-and-drop alongside menu and toolbar entry points
+- Multi-file workflows benefit from `NSOpenPanel.allowsMultipleSelection = true` and equivalent SwiftUI options
 
 ## Recent documents and multiwindow work
 
 - Support multiple open documents or windows where comparison and parallel work are natural
-- Preserve recent-document behavior if you build on document frameworks
+- Preserve recent-document behavior automatically via `NSDocumentController` or `DocumentGroup`
 - Let document frameworks handle autosave and version-oriented behavior when they fit the product
+- For document tabs (`NSWindow.tabbingMode`), respect the system "Prefer Tabs" setting
 
 ## Finder-facing behavior
 
-- Use meaningful file types and `UTType` declarations
-- Support Quick Look for custom formats when preview matters
-- Provide sensible icons, names, and exported metadata
+- Use meaningful file types declared via `UTType`
+- Support Quick Look for custom formats when preview matters (`NSDocument.previewItemURL` or a Quick Look extension)
+- Provide sensible icons, names, and exported metadata via Info.plist `UTExportedTypeDeclarations`
 - Respect Finder conventions instead of inventing a parallel file browser unless the product truly needs one
 
 ## Sandboxed file access
 
-- For external user-chosen files or folders, rely on system panels and security-scoped access
+- For external user-chosen files or folders, rely on system panels and security-scoped access — the panel grants the entitlement; you don't request paths arbitrarily
 - Persist access with security-scoped bookmarks only when the workflow truly needs cross-launch access
-- Always balance `startAccessingSecurityScopedResource()` with `stopAccessingSecurityScopedResource()`
+- Always balance `startAccessingSecurityScopedResource()` with `stopAccessingSecurityScopedResource()` — leaks here cause subtle long-running bugs
+- Bookmark resolution in a sandboxed app may return stale URLs; handle the resolution failure path
+
+## Drag and drop for file workflows
+
+- Accept dropped files via `.dropDestination(for: URL.self) { … }` (SwiftUI) or `NSDraggingDestination` (AppKit)
+- For dragging files **out** to Finder with lazy generation, you need `NSFilePromiseProvider` — there is no SwiftUI equivalent. Bridge if drag-out-to-Finder is required
+- For drag-source lifecycle (cancellation handling, drop-outside-window detection), bridge to `NSDraggingSource`. SwiftUI's `.draggable(_:)` has no session-end callback. See `menus-commands-input.md` for the full discussion
 
 ## Do not
 
-- Store large user documents in `UserDefaults`
-- Build custom fake “open” and “save” flows when Apple’s panels fit
+- Store large user documents in `UserDefaults` — it's not the right tool, and large defaults slow login and sync
+- Build custom fake "open" and "save" flows when Apple's panels fit
 - Treat import/export as an afterthought in file-centric apps
 - Assume sandboxed apps can read arbitrary paths without user consent or entitlements
+- Use `Codable`+`UserDefaults` as a persistence layer for primary user data — that's what files or SwiftData are for
 
 ## Review checklist
 
-- The app uses the correct document model for the workflow
-- Open/save/import/export are clearly separated and use standard UI
-- Drag-and-drop supports common file workflows
-- File access rules and sandbox implications are handled correctly
-- Custom file types are previewable and well-integrated where appropriate
+- The app uses the correct document model for the workflow (document-based vs app-managed)
+- Open/save/import/export are clearly separated and use system panels
+- Drag-and-drop supports common file workflows; file promises bridge to AppKit when drag-out is required
+- File access rules and sandbox implications are handled correctly, including bookmark balancing
+- Custom file types are declared via `UTType` and previewable via Quick Look where it matters
+- Recent documents and document tabs work the system way
 
 ## Pair this file with
 
-- `menus-commands-input.md` for drag-and-drop, clipboard, and file-related commands
+- `menus-commands-input.md` for drag-and-drop, clipboard, and file-related commands plus drag-source lifecycle gaps
 - `persistence-and-data.md` for choosing between file-based and database-backed storage
 - `platform-capabilities-distribution.md` for sandboxing, entitlements, and security-scoped bookmarks
-- `swiftui-macos.md` for SwiftUI file workflow APIs
+- `swiftui-macos.md` for SwiftUI file workflow APIs and known gaps
+- `appkit-and-bridging.md` for `NSDocument`, `NSFilePromiseProvider`, and Quick Look integration

--- a/macos-expert/references/menus-commands-input.md
+++ b/macos-expert/references/menus-commands-input.md
@@ -1,6 +1,8 @@
 # Menus, commands, shortcuts, and input
 
-Menus and commands are part of the product surface on macOS. Treat them as first-class UI.
+Menus, commands, and the responder chain are part of the product surface on macOS. Treat them as first-class UI, not a polish layer.
+
+This file covers menu structure, keyboard expectations, context menus, drag-and-drop, and the SwiftUI gaps in each — so you know when SwiftUI primitives are enough and when AppKit's responder chain wins.
 
 ## Standard menu expectations
 
@@ -15,13 +17,15 @@ Preserve the standard macOS structure unless there is a strong reason not to:
 
 Add custom menus only when a domain has enough commands to justify one.
 
-Keep standard menu items visible even when they are temporarily unavailable; disable them instead of hiding them.
+Keep standard menu items visible even when temporarily unavailable; **disable**, don't hide. The Mac convention is that menu items are discoverable in the same place every time.
 
 ## App-wide menu basics
 
-- Put About, Settings, app visibility items, and Quit in the app menu
-- Support the system-provided Services submenu when it applies to the current context
-- Use the Help menu for help content and keep it small and focused
+- Put About, Settings, Hide, Hide Others, Show All, and Quit in the app menu (SwiftUI's `Settings` scene wires ⌘, automatically)
+- Support the system Services submenu where it applies to the current context
+- Help menu is small and focused
+- File menu has New (`⌘N`), Open (`⌘O`), Open Recent, Close (`⌘W`), Save (`⌘S`), Save As (`⇧⌘S`), Revert, Print (`⌘P`) where applicable
+- Edit menu has standard Cut/Copy/Paste/Delete/Select All plus Undo/Redo and Find/Find Next where applicable
 
 ## Command coverage
 
@@ -32,6 +36,8 @@ Core actions should usually be available in more than one place:
 - Keyboard shortcut for speed when appropriate
 - Context menu when the action is object-specific
 
+This is the "law of three places" Mac users internalize. Skipping the menu is the most common iOS-import mistake.
+
 ## Keyboard shortcuts
 
 Prefer established conventions:
@@ -40,23 +46,30 @@ Prefer established conventions:
 - Open: `⌘O`
 - Save: `⌘S`
 - Close window: `⌘W`
+- Quit: `⌘Q`
 - Undo / Redo: `⌘Z` / `⇧⌘Z`
-- Find: `⌘F`
+- Find / Find Next / Find Previous: `⌘F` / `⌘G` / `⇧⌘G`
 - Preferences / Settings: `⌘,`
+- Print: `⌘P`
+- Select All: `⌘A`
+- Cut / Copy / Paste: `⌘X` / `⌘C` / `⌘V`
+- Hide / Hide Others: `⌘H` / `⌥⌘H`
+- Minimize: `⌘M`
+- Toggle full-screen: `⌃⌘F`
 
-Do not override fundamental system shortcuts casually.
+Do not override fundamental system shortcuts casually. If you must, use a modifier combination that doesn't collide with system reservations.
 
 ## Undo, redo, clipboard, and selection
 
 For editable content, support the Mac basics:
 
-- Undo / redo
-- Cut / copy / paste
+- Undo / redo (use `UndoManager`; SwiftUI `@Environment(\.undoManager)`)
+- Cut / copy / paste / delete
 - Select all
 - Find / replace where text is central
 - Drag and drop for reordering or file ingress/egress when relevant
 
-If the app owns rich document workflows, commands should integrate cleanly with the responder chain or SwiftUI command system.
+If the app owns rich document workflows, commands should integrate with the responder chain or SwiftUI's `.commands` system. AppKit's responder chain delivers the action to the focused control automatically; SwiftUI's `.commands` is global to the scene and is not focus-aware in the same way (see `appkit-and-bridging.md` for the gap).
 
 ## Context menus
 
@@ -67,58 +80,138 @@ Use context menus to accelerate object-level actions:
 - Duplicate
 - Move
 - Share
-- Delete
+- Show in Finder / Reveal
+- Delete (destructive role)
 
-Context menus should supplement the app’s main command surface, not replace it.
+Context menus should supplement the app's main command surface, not replace it.
+
+### SwiftUI context menu options
+
+- `.contextMenu(menuItems:)` — simple, view-attached menu. macOS doesn't show the contextMenu *preview* on Mac (Apple's docs note this explicitly: "This view modifier produces a context menu on macOS, but that platform doesn't display a preview")
+- `.contextMenu(forSelectionType:menu:primaryAction:)` (macOS 13.0+) — selection-aware menu attached to a `List` or `Table`. The closure receives a `Set<I>` of selected items; an empty set means activation in empty space
+- `primaryAction:` runs on macOS double-click / iOS tap
+
+### What SwiftUI context menus don't do
+
+- **No "menu is open" signal.** No environment value, no callback. You cannot dim the rest of the UI or change row styling while the menu is up
+- **No focus ring on the right-clicked row** in custom containers. `NSTableView` and `NSOutlineView` automatically draw a focus ring on the right-clicked row even when it isn't selected; SwiftUI's `List` does this internally but you can't customize it, and `ScrollView`/`LazyVStack` rows get nothing
+- **No way to vary preview shape** beyond `contentShape(_:_:eoFill:)` with `.contextMenuPreview` kind on iOS
+
+If knowing the menu state is operationally important, bridge to AppKit's `NSMenu` and `menuNeedsUpdate(_:)` / `menu(_:willHighlight:)`.
 
 ## Dock menus
 
-Dock menus are a useful macOS-only shortcut surface for high-value actions when the app is running but not frontmost.
+Dock menus are a macOS-only shortcut surface for high-value actions when the app is running but not frontmost.
 
-- Prefer a small set of high-value items like recent or open windows, new-item actions, or refresh/sync actions
-- Make custom Dock menu items available elsewhere too, such as in the menu bar or main UI
-- Do not treat the Dock menu as the only route to an important command
+- Prefer a small set of high-value items (recent windows, new-item actions, refresh/sync)
+- Make custom Dock menu items available elsewhere too — never the only route to a command
+- SwiftUI: `.commands` doesn't expose Dock menu directly; use `NSApplicationDelegate.applicationDockMenu(_:)` (which SwiftUI lets you wire via `@NSApplicationDelegateAdaptor`)
 
 ## Pointer and keyboard interaction
 
-- Hover can enhance but must not be the only way to discover or trigger important actions
+- Hover affordances must not be the only way to discover or trigger important actions — keyboard and click paths must work too
 - Keyboard focus order must be logical
-- Lists and tables should work with arrow keys, selection, and standard activation patterns
-- Right-click and control-click should reveal contextual actions where users expect them
+- Lists and tables must work with arrow keys and standard activation (Return, Space, Enter)
+- Right-click and Control-click must reveal contextual actions where users expect them
+- `.help(_:)` for tooltips on focusable controls
+
+## Keyboard handling and the SwiftUI gap
+
+SwiftUI offers a layered set of keyboard primitives:
+
+- `keyboardShortcut(_:modifiers:)` — declares a shortcut for a button or command
+- `.commands { CommandMenu("…") { Button("Action", action: …).keyboardShortcut(…) } }` — declares scene-level commands
+- `onKeyPress(_:action:)` and variants (macOS 14.0+ / iOS 17.0+) — observe key events on a focused view; return `.handled` or `.ignored`
+- `onMoveCommand(perform:)` — arrow-key handler. **macOS 10.15+ and tvOS 13.0+ only — not iOS or iPadOS.** This is a real cross-platform footgun
+- `onDeleteCommand`, `onExitCommand`, `onPlayPauseCommand` — semantic commands
+
+### What SwiftUI keyboard handling doesn't do
+
+- **The Spotlight pattern.** When a `TextField` has focus, it consumes character input including arrow keys for cursor movement. `onKeyPress` returning `.ignored` is partial mitigation, but the TextField is still the first responder. AppKit's responder chain with explicit `keyDown(with:)` overrides on a subclassed `NSTextField` or `NSSearchField` is the right tool when you need search-while-typing with arrow-nav-through-results
+- **Non-focused key handling.** `onKeyPress` only fires when the view is focused. AppKit's `NSResponder.keyDown(with:)` overrides plus `performKeyEquivalent(with:)` give you precise control without focus
+- **Cross-platform arrow keys.** `onMoveCommand` works on macOS/tvOS; on iPadOS you need `onKeyPress(.upArrow)` etc. with different semantics. Cross-platform code needs `#if` branches
+
+### When to bridge to AppKit for keys
+
+- Search field with arrow keys navigating result list
+- vim-style or modal key handling
+- Chord shortcuts (multi-key sequences)
+- Menu validation that depends on which view has focus
+- Any custom `NSResponder` participation in the chain
 
 ## Drag and drop
 
 Treat drag and drop as a core Mac affordance in file-centric and list-centric apps:
 
-- Accept dropped files when importing is central to the workflow
+- Accept dropped files when importing is central
 - Support dragging items out when export or reuse makes sense
-- Support reordering by drag where lists or collections are user-managed
+- Support reordering by drag where lists are user-managed
+
+### SwiftUI drag and drop
+
+- `.draggable(_:)` — declare a view as a drag source with a `Transferable` payload (macOS 13.0+)
+- `.draggable(_:preview:)` — same, with a custom preview view
+- `.dropDestination(for:action:isTargeted:)` — drop target with `Transferable`
+- `Transferable` and `ProxyRepresentation` for payload types
+
+### What SwiftUI drag-and-drop doesn't do
+
+Apple's documentation lists exactly two related modifiers next to `draggable(_:)`: `draggable(_:preview:)` and `dropDestination(…)`. There is no SwiftUI equivalent to:
+
+- `NSDraggingSource.draggingSession(_:willBeginAt:)` — drag started callback with location
+- `NSDraggingSource.draggingSession(_:movedTo:)` — drag-in-progress callback
+- `NSDraggingSource.draggingSession(_:endedAt:operation:)` — **drag ended, success or cancellation, with the operation result**
+- `NSDraggingSource.ignoreModifierKeys(for:)` — modifier-key behavior control
+- `NSFilePromiseProvider` — lazy file generation for drops to Finder
+- Per-item drag images that differ from the source view rendering
+- Multi-component drag images via `NSDraggingItem.imageComponentsProvider`
+
+This means you cannot:
+
+- Dim the source on drag start and reliably undim it on cancel/abort
+- React when the drop target was outside the window or returned no operation
+- Promise files that should be created lazily on drop
+
+### When to bridge to AppKit for drag
+
+- Drag rearrangement in lists with live drop indicators (use `NSTableView`/`NSOutlineView`, both `NSDraggingSource` conforming)
+- Dragging-out-to-Finder with file promises (`NSFilePromiseProvider`)
+- Any UI behavior that depends on drag-end state
+- Modifier-key-aware drag behavior
+
+The conforming AppKit types out of the box: `NSCollectionView`, `NSOutlineView`, `NSTableView`, `NSTextView`. They give you the full lifecycle for free.
 
 ## SwiftUI tools
 
-- `.commands`
-- `CommandGroup` and `CommandMenu`
-- `.keyboardShortcut`
-- `.contextMenu`
-- `.draggable` and `.dropDestination`
-- `@FocusState`
-- `.help`
+- `.commands`, `CommandGroup`, `CommandMenu`, `CommandGroupPlacement` (`.replacing`, `.before`, `.after`)
+- `.keyboardShortcut(_:modifiers:)`
+- `.contextMenu(menuItems:)` and `.contextMenu(forSelectionType:menu:primaryAction:)`
+- `.draggable(_:)` and `.dropDestination(for:action:isTargeted:)`
+- `@FocusState`, `.focusable(_:)`, `.focused(_:)`
+- `.onKeyPress(_:action:)`, `.onMoveCommand(perform:)`, `.onDeleteCommand`, `.onExitCommand`
+- `.help(_:)` for tooltips
+- `@Environment(\.undoManager)`
 
 ## AppKit tools
 
 - `NSMenu`, `NSMenuItem`, `NSMenuItemValidation`
-- responder chain actions
-- `NSPasteboard`
-- `NSDraggingSource` and `NSDraggingDestination`
-- `validateUserInterfaceItem(_:)`
+- `NSMenuDelegate.menuNeedsUpdate(_:)` for dynamic context menus
+- Responder chain actions and `NSResponder.keyDown(with:)`
+- `validateUserInterfaceItem(_:)` and `NSUserInterfaceValidations`
+- `NSPasteboard`, `NSPasteboardItem`, `NSPasteboardWriting`, `NSPasteboardReading`
+- `NSDraggingSource`, `NSDraggingDestination`, `NSDraggingItem`, `NSDraggingSession`
+- `NSFilePromiseProvider`
+- `UndoManager`
 
 ## Review checklist
 
-- The app’s primary actions are visible in menus
+- Primary actions appear in menus, not only in toolbars or popovers
 - Important shortcuts follow Mac conventions
 - Undo/redo and copy/paste exist where users expect them
 - Context menus and drag-and-drop improve workflows instead of duplicating clutter
 - Keyboard navigation is complete enough for expert use
+- If keyboard or drag handling needs lifecycle behavior SwiftUI can't express, AppKit is used at that seam
+- Menu validation is responder-chain-aware where focus matters
 
 ## Pair this file with
 
@@ -126,3 +219,4 @@ Treat drag and drop as a core Mac affordance in file-centric and list-centric ap
 - `windows-navigation.md` for toolbar placement and window structure
 - `accessibility.md` for keyboard navigation and focus requirements
 - `file-management-documents.md` for drag-and-drop file workflows
+- `appkit-and-bridging.md` for responder chain, menu validation, and AppKit drag/menu bridging

--- a/macos-expert/references/official-sources.md
+++ b/macos-expert/references/official-sources.md
@@ -1,12 +1,12 @@
 # Official sources and verification workflow
 
-Use Apple’s own materials as the source of truth for this skill.
+Use Apple's own materials as the source of truth for this skill. The skill files codify patterns; Apple's docs codify APIs. When the two disagree, Apple wins and the skill file should be updated.
 
 ## Source hierarchy
 
 1. **Apple Human Interface Guidelines**
    - `Designing for macOS`
-   - topic pages for windows, menus, toolbars, sidebars, file management, drag and drop, and full-screen behavior
+   - Topic pages for windows, menus, toolbars, sidebars, file management, drag and drop, full-screen behavior
 2. **Apple Developer API documentation**
    - SwiftUI
    - AppKit
@@ -17,34 +17,66 @@ Use Apple’s own materials as the source of truth for this skill.
    - Uniform Type Identifiers
    - Security-scoped bookmarks and sandbox-related docs
 3. **Apple release notes and WWDC sessions**
-   - Use for version-specific changes and new platform behavior
+   - For version-specific changes and new platform behavior
+4. **WWDC sample code and the "Building a great Mac app with SwiftUI" sample**
+   - For up-to-date Apple-blessed patterns
 
 ## Verification workflow
 
-Use current official Apple documentation to verify APIs and behavior:
+When recommending an API or modifier, verify it against Apple's current docs:
 
 1. Search for the concrete symbol or topic
-2. If a search for several words fails, search smaller pieces like the exact type or modifier name
+2. If a multi-word search fails, search the exact type or modifier name
 3. Load the matching page before claiming the API exists or recommending its usage
-4. If you cannot find the API in Apple’s current documentation, assume the name may be wrong or outdated and reframe the answer around verified APIs
+4. **Read the "Available on" line carefully** — this is where most stale guidance fails. APIs that exist on macOS 14+ may not exist on macOS 13, and APIs that exist on macOS may not exist on iOS or vice versa
+5. **Read the Discussion section** — Apple often documents constraints there that aren't visible from the signature alone (e.g. "this only works inside `List` and `Table`")
+6. If you cannot find the API in Apple's current documentation, assume the name may be wrong, deprecated, or third-party and reframe the answer around verified APIs
+
+## Platform availability — the most common stale-guidance bug
+
+SwiftUI APIs are not uniformly available across platforms. Recurring traps:
+
+- `onMoveCommand(perform:)` — macOS 10.15+ and tvOS 13.0+ only. **Not iOS or iPadOS.** Cross-platform code must guard with `#if`
+- `onKeyPress(_:action:)` — iOS 17.0+ / macOS 14.0+. Doesn't exist on older targets
+- `MenuBarExtra` — macOS 13.0+ only
+- `Window` (singular scene) — macOS 13.0+ only; older code must use `WindowGroup`
+- `.inspector(isPresented:content:)` — macOS 14.0+ / iOS 17.0+
+- `appearsActive` — exists on iOS 18+ / macOS 15+ in declared form, back-deployed to macOS 10.15. Use the back-deployed shim where appropriate
+- `backgroundProminence` — iOS 17+ / macOS 14+, **and only inside `List`/`Table`**
+- `.contextMenu(forSelectionType:menu:primaryAction:)` — macOS 13.0+ / iOS 16.0+
+- `.draggable(_:)` and `.draggable(_:preview:)` — macOS 13.0+ / iOS 16.0+
+
+When deployment target matters, always check the "Available on" line.
 
 ## What must be verified
 
-Verify in official docs when any of these appear:
+Verify in official docs whenever any of these appear in your guidance:
 
 - New or unfamiliar SwiftUI modifiers
 - Entitlements, Info.plist keys, or sandbox behavior
-- New menu bar, background task, or extension APIs
+- Menu bar, background task, or extension APIs
 - Availability by macOS version
-- Any newly announced or rapidly changing platform claims
+- Any newly announced or rapidly changing platform claims (especially within 18 months of WWDC release)
+- SwiftData behavior on the macOS version targeted (this surface has changed meaningfully release-to-release)
+- CloudKit, ServiceManagement, and notarization tooling (`notarytool` vs `altool`)
 
 ## Topic-to-source map
 
 - **Design and UX** → HIG pages
 - **Framework and symbols** → Apple API reference documentation
-- **Availability / modern platform changes** → API docs, release notes, WWDC
-- **Distribution / signing / notarization** → Apple developer docs
+- **Availability / modern platform changes** → API docs ("Available on" line), release notes, WWDC sessions
+- **Distribution / signing / notarization** → Apple developer docs (`Distributing your app`, notarization, hardened runtime pages)
+- **Sample code patterns** → official Apple sample projects, especially the SwiftUI Mac app sample
 
 ## Working rule
 
-If any draft guidance disagrees with Apple’s current documentation, prefer Apple and update the draft guidance.
+If any draft guidance disagrees with Apple's current documentation, prefer Apple and update the draft guidance. If guidance describes a *gap* in an API (something the API doesn't do), confirm the gap by reading the related-APIs section of Apple's doc — if Apple lists no API for the missing capability, the gap is real.
+
+## When Apple's docs are silent
+
+Some real platform behavior isn't documented (or is documented only in WWDC video transcripts). For those cases:
+
+- Treat the WWDC transcript as a primary source
+- Treat well-respected community write-ups (e.g. observations from Apple-experienced developers) as secondary signal, not authoritative
+- Note explicitly when guidance is based on observation rather than Apple's published docs, so future updates can re-verify
+- Prefer a verifiable, narrower claim over an unverifiable, broader one

--- a/macos-expert/references/persistence-and-data.md
+++ b/macos-expert/references/persistence-and-data.md
@@ -1,56 +1,82 @@
 # Persistence and data choices
 
-Choose storage by the user’s mental model and the app’s data shape, not by habit.
+Choose storage by the user's mental model and the app's data shape, not by habit. The wrong choice is hard to undo because it leaks into the UI, the sync model, and the migration plan.
 
 ## Pick the right storage model
 
 - **User preferences** → `UserDefaults` / `@AppStorage`
+- **Per-window or per-scene state restoration** → `@SceneStorage` (don't put this in `UserDefaults`)
 - **User-owned documents** → file-based documents with `DocumentGroup`, `FileDocument`, `ReferenceFileDocument`, or `NSDocument`
 - **Relational app data for modern targets** → SwiftData
 - **Legacy or advanced persistence needs** → Core Data
 - **Shared app/extension data** → App Group container plus the appropriate store type
+- **Cross-device sync of app data** → CloudKit (directly, or via SwiftData/Core Data CloudKit integration) — see `platform-capabilities-distribution.md`
 
 ## SwiftData guidance
 
-- Use SwiftData for modern macOS targets when the app owns structured relational data
-- Use `@Query` in simple SwiftUI views
+- Use SwiftData for modern macOS targets when the app owns structured relational data — but check current Apple docs for known issues on the macOS version you're targeting; SwiftData on Mac has had real friction in recent releases
+- Use `@Query` in simple SwiftUI views with bounded result sets
 - Use `FetchDescriptor`, `fetchCount`, and background workers for service-layer or high-volume operations
-- Use `@ModelActor` / `ModelActor` for background writes and bulk work
-- Set fetch limits for bounded UI
-- Plan migrations for schema changes instead of assuming they are free
+- Use `@ModelActor` / `ModelActor` for background writes and bulk work — don't do bulk inserts on the main `ModelContext`
+- Set fetch limits for bounded UI; don't `@Query` an unbounded table into a list
+- Plan migrations for schema changes; lightweight migration is not free, and unique-constraint changes can require a custom migration plan
+- Test with realistic data volume before assuming SwiftData performance will hold
+
+If you're hitting performance walls, lifecycle weirdness, or migration complexity that SwiftData doesn't expose, Core Data is still a valid call. Don't migrate from working Core Data to SwiftData just for fashion.
+
+## Core Data guidance
+
+- Still the right tool for: complex relationships with custom fetched properties, fine-grained NSManagedObject subclass behavior, mature CloudKit sync (`NSPersistentCloudKitContainer`), or large-scale apps already invested in it
+- Use `NSPersistentContainer` and per-context concurrency types (`mainContext` vs `newBackgroundContext`)
+- Save merge policies explicitly; default policy on conflict can silently drop changes
+- Use `NSFetchedResultsController` for AppKit-bound UI, or `@FetchRequest` / `@SectionedFetchRequest` in SwiftUI views, when the UI must reflect store changes live and you're not on SwiftData
 
 ## File-based documents
 
 If the user thinks in files, make the data model file-shaped:
 
-- opening and saving should operate on real files
-- import/export should be explicit when conversion is involved
-- document windows should reflect document lifecycle and state
+- Opening and saving operate on real files
+- Import/export are explicit when format conversion is involved
+- Document windows reflect document lifecycle and state (modified indicator, tab grouping, version browser)
+- Use `FileDocument` for simple value semantics, `ReferenceFileDocument` when you need class semantics or undo grouping
+- For complex document apps with versioning, autosave, and tabs, `NSDocument` is still the most complete tool
 
-Do not force a database-shaped UX onto a document-shaped product.
+Do not force a database-shaped UX onto a document-shaped product, and vice versa.
 
 ## Preferences and lightweight settings
 
-- Keep `UserDefaults` for preferences, flags, window choices, and small settings
-- Do not put large blobs, primary records, or user documents in `UserDefaults`
+- `UserDefaults` for preferences, flags, window choices, and small structured settings
+- `@AppStorage` is the SwiftUI bridge — fine for primitives and small `Codable` values
+- Don't put large blobs, primary records, or user documents in `UserDefaults`
+- Don't put security-sensitive values in `UserDefaults` — Keychain (`kSecClass…`) is the right tool
+
+## Window-scoped state
+
+- `@SceneStorage` for per-scene restoration (sidebar visibility, selection, scroll position)
+- AppKit equivalents: `NSWindow.restorationClass` and the `NSResponder` `encodeRestorableState`/`restoreState` plumbing
+- Don't conflate per-scene UI state with app-global preferences
 
 ## Data integrity rules
 
-- Keep persistence APIs off the main thread for heavy work
+- Keep heavy persistence work off the main thread
 - Distinguish read models from write paths where complexity demands it
-- Treat migrations, uniqueness, and deletion rules as product behavior, not just schema details
-- Test realistic data volume, not only toy datasets
+- Treat migrations, uniqueness constraints, and deletion rules as product behavior, not just schema details
+- Test realistic data volume, not only toy datasets — performance regressions show up at the 10k–100k record threshold for most stores
+- For CloudKit-backed stores, plan for conflict resolution explicitly; "last writer wins" is rarely what users expect
 
 ## Review checklist
 
-- Storage choice matches the user’s mental model
-- SwiftData is used where it helps, not as a reflex
-- File/document workflows are file-native when appropriate
-- Preferences are separated from user content
-- Background work, fetch size, and migration risks are considered
+- Storage choice matches the user's mental model
+- SwiftData is used where it helps, not as a reflex; Core Data is a valid choice when SwiftData doesn't fit
+- File / document workflows are file-native when the user thinks in files
+- Preferences are separated from user content; sensitive values are in Keychain
+- Per-scene state uses `@SceneStorage` or AppKit restoration, not `UserDefaults`
+- Background work, fetch size, and migration risks are considered before shipping
+- Cross-device sync (if any) has explicit conflict and offline behavior
 
 ## Pair this file with
 
 - `file-management-documents.md` for document-based app workflows and file storage
-- `swiftui-macos.md` for SwiftUI data flow and observation patterns
-- `platform-capabilities-distribution.md` for App Groups, sandboxing, and shared containers
+- `swiftui-macos.md` for SwiftUI data flow, observation, and `@SceneStorage` patterns
+- `platform-capabilities-distribution.md` for App Groups, sandboxing, shared containers, and CloudKit
+- `official-sources.md` for verifying SwiftData and CloudKit availability and behavior on the macOS version you target

--- a/macos-expert/references/platform-capabilities-distribution.md
+++ b/macos-expert/references/platform-capabilities-distribution.md
@@ -1,55 +1,92 @@
 # Platform capabilities and distribution
 
-Mac-specific features often have UX, entitlement, and shipping implications at the same time. Address all three.
+Mac-specific features often have UX, entitlement, and shipping implications at the same time. Address all three together — entitlements drive what the app can do, sandbox configuration drives what it can read and write, and distribution channel drives both.
 
 ## Sandboxing
 
 - Request the smallest entitlement set that satisfies the workflow
-- Use user intent plus system panels for external file access
-- Use security-scoped bookmarks only for persistent access that users expect
-- Treat sandboxing as part of product design, not just release configuration
+- Use user intent plus system panels (`NSOpenPanel`, `.fileImporter`) for external file access — the panel grants the entitlement, you don't claim arbitrary paths
+- Use security-scoped bookmarks only for persistent access that users expect to survive launches
+- Treat sandboxing as part of product design, not just release configuration — workflows that require home-folder traversal need different UX than workflows that operate on a chosen file
+- Always balance `startAccessingSecurityScopedResource()` with `stopAccessingSecurityScopedResource()`; leaks here cause subtle long-running issues
+- Mac App Store distribution **requires** sandboxing; Developer ID distribution does not, but Hardened Runtime is required regardless for notarization
+
+## Common entitlements
+
+- `com.apple.security.app-sandbox` — sandbox itself
+- `com.apple.security.files.user-selected.read-only` / `.read-write` — granted by file panels
+- `com.apple.security.files.bookmarks.app-scope` — security-scoped bookmark resolution
+- `com.apple.security.network.client` / `.server` — outgoing / incoming network
+- `com.apple.security.device.audio-input` / `.camera` — capture entitlements (also need usage descriptions in Info.plist)
+- `com.apple.security.application-groups` — App Group container access
+- `com.apple.security.cs.allow-jit` and friends — JIT and code-signing relaxations (rare; document the reason)
+
+Verify exact entitlement keys against current Apple documentation; the list evolves, and the wrong key produces silent failures rather than build errors.
 
 ## Menu bar and background utilities
 
-- Use `MenuBarExtra` for modern SwiftUI menu bar apps
-- Use `NSStatusItem` when AppKit-level control is required
-- Keep menu bar apps focused and lightweight
-- If the app launches at login, use `SMAppService` and surface status clearly to the user
+- Use `MenuBarExtra` for modern SwiftUI menu bar apps (macOS 13.0+)
+- Use `NSStatusItem` when you need AppKit-level control: custom views, manual click-handling, modifier-aware menus
+- Pair menu-bar-only apps with `LSUIElement = true` in Info.plist to suppress Dock and app switcher presence
+- Keep menu bar apps focused and lightweight — users will remove the icon if it's busy or buggy
+- If the app launches at login, use `SMAppService` (macOS 13+) — the modern replacement for `SMLoginItemSetEnabled`. Surface launch-at-login state clearly to the user with a settings toggle
 
 ## Extensions and integrations
 
 Reach for extensions or separate processes when the product truly needs them:
 
-- Share extensions
-- Finder Sync
-- Quick Look preview or thumbnail support
-- XPC services for isolation or separation of privilege
+- **Share extensions** — for "share to your app" from other apps
+- **Action extensions** — for service-style transformations
+- **Finder Sync extensions** — for cloud-storage badge overlays and Finder context menu items
+- **Quick Look preview / thumbnail extensions** — for custom file types
+- **XPC services** — for isolation, separation of privilege, or running long-lived work outside the main process
+- **Network extensions** — VPN, content filters, DNS proxies; require special entitlements
 
-Do not add an extension target just to mirror functionality that belongs in the main app.
+Don't add an extension target just to mirror functionality that belongs in the main app. Extension overhead (separate bundle, separate signing, separate sandbox) only pays off when the extension reaches a context the main app can't.
 
 ## Privacy and user trust
 
-- Keep permission requests tightly connected to user intent
-- Ensure Info.plist usage descriptions are clear and specific
+- Permission requests should be tightly connected to user intent — request the camera when the user clicks "Start camera", not at launch
+- Info.plist usage descriptions (`NSCameraUsageDescription`, `NSMicrophoneUsageDescription`, `NSDesktopFolderUsageDescription`, etc.) must be specific and honest — Apple may reject vague descriptions
 - Explain why background behavior, file access, or device access exists when it may surprise the user
+- Telemetry and crash reporting need explicit user-visible disclosure on macOS
 
 ## Distribution
 
-- **Mac App Store**: sandboxing and review requirements shape the implementation
-- **Direct distribution**: plan for Developer ID signing, Hardened Runtime, and notarization as part of the product’s normal shipping path
-- Be explicit about what differs between store and direct builds if the feature set changes
+- **Mac App Store** — sandboxing is mandatory, review process applies, in-app purchase via StoreKit
+- **Developer ID (direct distribution)** — Hardened Runtime required for notarization, signing with a Developer ID Application certificate, notarization via `notarytool`, stapling the ticket onto the artifact
+- **Hybrid** — many apps ship both. Plan for entitlement and feature differences explicitly; some entitlements (like network extensions) require approvals that differ between channels
+
+## Code signing and notarization workflow
+
+- Signing identity: Developer ID Application certificate for direct distribution; Apple Distribution for the App Store
+- Hardened Runtime is required for notarization; enable it in build settings
+- Use `notarytool submit … --wait` (the modern tool; `altool` is deprecated)
+- Staple after notarization with `xcrun stapler staple <artifact>`
+- Verify with `spctl --assess --verbose <artifact>` before shipping
+- Plan signing and notarization into CI early — late surprises here block releases
+
+## Universal binaries
+
+- Build for `arm64` and `x86_64` if you support Macs older than Apple Silicon-only deployment
+- If you depend on Intel-only or arm64-only third-party binaries, verify both arches at link time
+- Test under Rosetta 2 only if you actually ship to Intel-equipped users
 
 ## Shipping checklist
 
-- entitlements are minimal and justified
-- background or login-item behavior is user-visible and reversible
-- extension boundaries are appropriate
-- privacy descriptions are accurate
-- signing, notarization, and distribution paths are planned early enough to avoid late surprises
+- Entitlements are minimal and justified; each one is needed by a real workflow
+- Sandbox-required workflows have user-intent-driven panel UX, not magic path access
+- Background or login-item behavior is user-visible and reversible
+- Extension boundaries are appropriate; no "extension because we wanted a target" anti-pattern
+- Privacy descriptions are accurate and specific
+- Signing, notarization, and distribution paths are wired into CI early
+- Universal binary status is correct for the deployment plan
+- Hybrid distribution differences (App Store vs Developer ID) are documented if the feature set differs
 
 ## Pair this file with
 
 - `file-management-documents.md` for sandboxed file access and security-scoped bookmarks
 - `persistence-and-data.md` for App Group containers and shared storage
-- `swiftui-macos.md` for MenuBarExtra and SwiftUI scene types
-- `official-sources.md` for verifying entitlements and Info.plist keys
+- `swiftui-macos.md` for `MenuBarExtra` and SwiftUI scene types
+- `appkit-and-bridging.md` for `NSStatusItem` and `NSApplicationDelegate` plumbing
+- `official-sources.md` for verifying entitlements, Info.plist keys, and distribution requirements

--- a/macos-expert/references/swiftui-macos.md
+++ b/macos-expert/references/swiftui-macos.md
@@ -1,66 +1,192 @@
 # SwiftUI for macOS
 
-Prefer SwiftUI patterns that feel native on macOS rather than cross-platform abstractions that flatten Mac behavior.
+SwiftUI on macOS is good for some app shapes and bad for others. This file is honest about which is which, names the concrete API gaps Apple's own documentation acknowledges, and tells you when to bridge to AppKit instead of working around SwiftUI's limits.
 
-## Reach for these first
+Verify any API claim here against current Apple docs (especially the "Available on" line and Discussion section) before relying on it. SwiftUI evolves; this file may lag.
 
-- `NavigationSplitView` for source/list/detail layouts
-- `Table` for data-heavy or sortable tabular content
-- `WindowGroup`, `Window`, `Settings`, and `DocumentGroup` for scenes
-- `.toolbar` and `.commands` for primary actions
-- `.searchable` for standard search UI instead of custom search chrome
-- `MenuBarExtra` for menu bar utilities
-- `.fileImporter`, `.fileExporter`, and `.dropDestination` for file workflows
+## Where SwiftUI is the right answer
+
+SwiftUI-only is fine and often best when the app is shaped like:
+
+- A **content browser**: lists of items, detail panes, light forms, settings — read-mostly, tap-to-drill
+- A **utility / menu bar app** without a heavy main window
+- A **document app** where the content area is your own custom drawing
+- A **cross-platform port** where iOS is the primary target and macOS rides along via `#if os(macOS)`
+- An app whose main interactions fit `NavigationSplitView` + `Table` + `.toolbar` + `.searchable` cleanly
+
+If your app's center of gravity matches the above, the rest of this file's caveats matter less. Use SwiftUI, ship, move on.
+
+## Where SwiftUI runs out of road
+
+SwiftUI is the wrong primary choice when the Mac-shaped product needs any of:
+
+- A **power-user list/outline** with multi-selection drag rearrangement, custom row styling that depends on focus/emphasis, or a context-menu focus ring on the right-clicked row
+- **Drag-source state** beyond "drag started" — knowing when the session ended, where, and with which operation
+- **Keyboard-first workflows** mixing focused text fields with arrow-key navigation through results (Spotlight pattern), modal key handling alongside text input, or vim-style navigation
+- **Deterministic toolbar layout** with explicit identifier order, allowed/default identifier lists, and overflow control
+- **Rich text editing** beyond plain `TextEditor` capabilities
+- **Custom window chrome** or detailed responder-chain control
+- **High-volume tables** where `Table` performance breaks down
+
+The concrete API gaps that drive this are listed below. None of them are speculation — they're observable from Apple's own documentation as of macOS 15 / SwiftUI's current shape.
+
+## Reach for these first (with current caveats)
+
+- `NavigationSplitView` for source/list/detail layouts.
+  - **macOS 13.0+.** Note: SwiftUI auto-adds a sidebar toggle toolbar item on macOS; remove it with `.toolbar(removing: .sidebarToggle)` if you need clean toolbar control (requires macOS 14+).
+- `Table` for sortable tabular content.
+  - **macOS 12.0+.** Single or multiple selection, sort descriptors, hierarchical rows, column customization. Adequate for tens of thousands of rows in practice; if you need NSTableView-class performance or fine-grained drawing, bridge.
+- `WindowGroup`, `Window`, `Settings`, `DocumentGroup` for scenes.
+  - `Settings` is the right home for preferences. `Window` (singular, macOS 13.0+) is the right home for a single-instance main window.
+- `MenuBarExtra` for menu bar utilities.
+  - **macOS 13.0+.** Use `.menuBarExtraStyle(.window)` for popover-like content panels. Set `LSUIElement` in Info.plist for menu-bar-only apps.
+- `.toolbar` and `.commands` for primary actions.
+  - See the toolbar caveat below — semantic placements are platform-variable by design.
+- `.searchable` for standard search.
+- `.fileImporter`, `.fileExporter`, `.fileMover` for system file panels.
+- `.contextMenu(forSelectionType:menu:primaryAction:)` for selection-aware item menus.
+  - See the context-menu caveat below.
 
 ## State and observation
 
-- Prefer the Observation framework on modern deployment targets
-- Keep view state local and lightweight
-- Move shared business state into observable models, actors, or repositories rather than bloated views
-- Keep window-scoped state separate from app-global state when users may open multiple windows
+- Use the Observation framework (`@Observable`, macOS 14+) on modern targets; `ObservableObject` on older ones.
+- Keep view state local; lift shared state to observable models, actors, or repositories.
+- Window-scoped state should be separate from app-global state when users may open multiple windows. `@SceneStorage` is the right tool for state that should restore per scene.
+- For per-document or per-window controllers that AppKit would model with `NSWindowController`, give them a real lifetime — don't hide them inside transient view structs.
 
 ## Scene and window design
 
-- Use additional windows for real secondary workspaces, not for every dialog-sized task
-- Keep settings in `Settings`
-- Use `DocumentGroup` when the app is truly document-based
-- Pair split-view layouts with toolbars and commands instead of overloading inline buttons
+- Use additional windows for genuinely separate workspaces, not for dialog-sized tasks. Use sheets, popovers, or inspectors for those.
+- `Settings` scene gets ⌘, automatically and lives in the app menu — don't reimplement it.
+- `DocumentGroup` only when the app is truly document-based. If you're shoving a database-backed app through it, you'll fight it.
+- Pair split-view layouts with toolbars and commands rather than overloading inline buttons.
 
 ## Commands, menus, and toolbars
 
-- Treat `.commands` as part of the product, not as an afterthought
-- Put high-frequency actions in the toolbar
-- Put complete command coverage in menus
-- Use standard shortcuts before inventing new ones
+- Treat `.commands` as part of the product surface, not as polish. Mac users expect complete menu coverage.
+- Toolbar gets the high-frequency actions; menus get complete coverage; shortcuts get the speed paths.
+- Use the standard shortcuts (⌘N, ⌘O, ⌘S, ⌘W, ⌘Z, ⇧⌘Z, ⌘F, ⌘,) before inventing.
+- `CommandGroup(replacing:)`, `CommandGroup(after:)`, `CommandGroup(before:)` are the right tools for mutating standard menus.
 
-## Mac-specific affordances
+### Toolbar placement is non-deterministic by design
 
-- Use `.contextMenu` and `.help`
-- Support keyboard focus with `@FocusState`
-- Use drag and drop for files, reordering, and object movement where appropriate
-- Prefer `Table` over custom grid layouts for true desktop data views
+Apple's `ToolbarItemPlacement` documentation states this directly: "SwiftUI determines the appropriate placement for the item based on this intent and its surrounding context, like the current platform." It also notes: "If not all items fit in the available space, an overflow menu may be created and remaining items placed in that menu."
 
-## When SwiftUI is not enough
+Implications for Mac-assed apps:
 
-Bridge to AppKit when you need:
+- `.primaryAction`, `.automatic`, `.secondaryAction`, `.principal` are **suggestions** to SwiftUI, not commands.
+- You cannot reliably predict where items appear in three-pane layouts.
+- There is no SwiftUI analogue to `NSToolbarDelegate.toolbarAllowedItemIdentifiers` or `toolbarDefaultItemIdentifiers` — no way to declare an explicit identifier list and let the system place items by identifier.
+- If the toolbar must be deterministic — exact ordering, exact overflow rules, customizable via the standard customization sheet — host the window in AppKit and use `NSToolbar`. SwiftUI inside the toolbar items is fine; SwiftUI managing the toolbar is the problem.
 
-- richer text editing
-- higher-performance tables or outlines
-- mature document architecture
-- highly customized windows or responder-chain behavior
-- advanced drag-and-drop, menu, or view lifecycle control
+## Mac-specific affordances — what works and what doesn't
+
+These are the SwiftUI primitives that map to AppKit affordances, with the gaps Apple's docs imply or state.
+
+### `.contextMenu` and `.contextMenu(forSelectionType:menu:primaryAction:)`
+
+Works for: showing a contextual menu, varying contents by selection set, attaching a primary (double-click) action.
+
+Does not work for:
+
+- **Knowing whether a context menu is currently open.** No environment value, no callback. If you need to dim the rest of the UI or change row styling while the menu is up, you cannot.
+- **Styling the context-menu target row.** AppKit's `NSTableView` draws a focus ring around the right-clicked row even when it isn't the selection; SwiftUI's `List` does this automatically and you can't customize it. Custom rows in `ScrollView`/`LazyVStack` get nothing.
+- **Distinguishing menu activation on a selection vs an empty area** beyond what `forSelectionType`'s closure tells you (empty set vs non-empty set). The selection itself is unchanged by right-click.
+
+### `.draggable(_:)` and `.draggable(_:preview:)`
+
+Works for: declaring a view as a drag source with `Transferable` payload and an optional preview view. **macOS 13.0+ / iOS 16.0+.**
+
+Does not work for:
+
+- **Drag-session lifecycle.** Apple's documentation lists the related APIs as exactly `draggable(_:preview:)` and `dropDestination(…)`. There is no SwiftUI equivalent to `NSDraggingSource.draggingSession(_:willBeginAt:)`, `draggingSession(_:movedTo:)`, or — most importantly — `draggingSession(_:endedAt:operation:)`.
+- **Knowing the drag was cancelled or dropped outside the window.** If you dim the source view on drag start, you have no callback to undim it on cancel/abort.
+- **Custom drag images per item, controlled at session level.** You get one preview per source view.
+
+If drag-and-drop is operationally important to your app (reorder, move-between-containers, drag-out-to-Finder, drag-with-modifier-keys), bridge to `NSDraggingSource`. The conforming AppKit views — `NSTableView`, `NSOutlineView`, `NSCollectionView`, `NSTextView` — give you the full lifecycle.
+
+### `@FocusState` and `.focusable(_:)`
+
+Works for: declaring focus state, moving focus between specific fields, gating actions on focused field. **`focusable(_:)` is macOS 12.0+.**
+
+Does not work for:
+
+- **The Spotlight pattern.** When a `TextField` has focus, it consumes character input including arrow keys for cursor movement. You can attach `onKeyPress(_:action:)` (macOS 14+ / iOS 17+) and return `.ignored` to bubble the event, but the TextField is still the first responder and the interaction model is fragile compared to AppKit's responder chain.
+- **Modal key handling alongside text editing.** AppKit's `keyDown(with:)` overrides on subclassed views give you precise control; SwiftUI's `onKeyPress` is an overlay that interacts opaquely with focus.
+
+If keyboard handling is central to the app — search bar with arrow nav through results, vim-style modes, chord shortcuts, modal key handling — host the window in AppKit.
+
+### `onMoveCommand(perform:)`
+
+Works for: arrow-key movement on macOS and tvOS.
+
+Does not work for:
+
+- **iPadOS or iOS.** Apple's documentation explicitly lists availability as "macOS 10.15+, tvOS 13.0+." iPad supports hardware keyboards but `onMoveCommand` does not. Cross-platform code needs `#if os(macOS) || os(tvOS)` for `onMoveCommand` and `onKeyPress` (iOS 17+ / macOS 14+) for the iPad path, with different semantics.
+
+### `onKeyPress(_:action:)` and variants
+
+Works for: hardware key handling on a focused view. **iOS 17.0+ / macOS 14.0+.** Returns `.handled` or `.ignored` so events can bubble.
+
+Does not work for:
+
+- **Pre-iOS 17 / pre-macOS 14 deployment targets.**
+- **First-responder-aware behavior.** It runs only when the view is focused. There is no SwiftUI analogue to `NSResponder.keyDown(with:)` on a non-focused view, and no equivalent to `performKeyEquivalent(with:)` on the responder chain.
+
+### `.help`, `.alternatingRowBackgrounds`, `.tableStyle`, `.searchable`, `.contentMargins`
+
+These are uncontroversial. Use them. Note availability: `.alternatingRowBackgrounds(_:)` is macOS 14+; `.contentMargins` is iOS 17+ / macOS 14+. The others are macOS 11+ or earlier.
+
+### Inactive-window appearance
+
+`@Environment(\.appearsActive)` (macOS 10.15+, back-deployed) gives you the active/inactive flag for current Mac apps. The deprecated `controlActiveState` maps to it. `Color.accentColor`, `ShapeStyle.selection`, and selection in `List`/`Table` automatically desaturate when inactive.
+
+For custom views, observe `\.appearsActive` and adjust styling. This is the one classic Mac affordance SwiftUI handles cleanly today.
+
+### De-emphasized selection in custom rows
+
+`@Environment(\.backgroundProminence)` (iOS 17+ / macOS 14+) communicates "this row is selected and currently emphasized" to children — but **only inside `List` and `Table`.** Apple's documentation states: "Views like `List` and `Table` … will automatically update the background prominence of foreground views."
+
+If you build custom row layouts in `ScrollView` + `LazyVStack` because `List` doesn't allow the customization you need, `backgroundProminence` won't help and you're back to manual focus tracking through environment plumbing.
+
+## Choosing the framework for the row container
+
+| Need | Use |
+|---|---|
+| Plain rows, system look, selection, swipe actions | `List` |
+| Tabular data, sortable columns, multi-select, column customization | `Table` |
+| Custom row layouts that don't need precise selection-emphasis behavior | `ScrollView` + `LazyVStack` |
+| Custom row layouts that **do** need selection emphasis, drag rearrangement, context-menu focus ring, or large data scale | bridge to `NSTableView` / `NSOutlineView` via `NSViewRepresentable` |
+
+## When SwiftUI is not enough — concrete trigger signals
+
+Bridge to AppKit (or build the shell in AppKit and host SwiftUI inside) when you hit any of these:
+
+- You're reaching for `ScrollView` + `LazyVStack` because `List` won't let you customize selection, and now you've lost selection emphasis behavior
+- You need `NSDraggingSource`'s `draggingSession(_:endedAt:operation:)` because something must happen when the drag is cancelled
+- You need a context menu focus ring on the right-clicked row, or to know the menu is open
+- You need a search field that lets arrow keys navigate the result list while the field has focus
+- You need deterministic toolbar layout, allowed/default identifier lists, or the standard toolbar customization sheet
+- You need rich text editing (attributed runs, custom layout, paragraph attributes) beyond `TextEditor`
+- You need `NSTableView`/`NSOutlineView` performance for tens of thousands of rows with custom drawing
+- You need detailed `NSWindow` control: custom title bar, accessory view controllers, tab groups, screensaver-class behavior
+
+The bridge can go either direction. See `appkit-and-bridging.md`.
 
 ## Review checklist
 
-- SwiftUI scene types match the app’s real workflow
-- Split-view, table, menu, and toolbar patterns feel native on macOS
-- Observation and state lifetimes are clean
-- Mac-specific affordances are present instead of emulated
-- AppKit is introduced only where SwiftUI meaningfully falls short
+- SwiftUI scene types match the app's real workflow (`Window` vs `WindowGroup` vs `DocumentGroup` vs `Settings` vs `MenuBarExtra`)
+- Power-user affordances (selection emphasis, drag lifecycle, context-menu focus, keyboard nav with focused text) either work natively or have a deliberate AppKit bridge
+- Toolbar items are simple enough that platform-variable placement is acceptable, **or** the toolbar is `NSToolbar`
+- Observation and state lifetimes are clean; window-scoped state uses `@SceneStorage` where appropriate
+- `@Observable` is used on modern targets
+- Cross-platform code accounts for `onMoveCommand` not existing on iOS/iPadOS
+- Bridging is introduced where SwiftUI demonstrably runs out of road, not as a hedge
 
 ## Pair this file with
 
 - `appkit-and-bridging.md` for when and how to bridge to AppKit
-- `windows-navigation.md` for window, toolbar, and navigation layout guidance
-- `menus-commands-input.md` for commands, shortcuts, and menu structure
+- `windows-navigation.md` for window, toolbar, and navigation layout guidance, including the toolbar determinism caveat
+- `menus-commands-input.md` for commands, shortcuts, menu structure, and drag-and-drop pitfalls
 - `persistence-and-data.md` for SwiftData and document storage choices
+- `official-sources.md` for verifying API availability before quoting modifiers in implementation guidance

--- a/macos-expert/references/swiftui-macos.md
+++ b/macos-expert/references/swiftui-macos.md
@@ -152,7 +152,7 @@ If you build custom row layouts in `ScrollView` + `LazyVStack` because `List` do
 ## Choosing the framework for the row container
 
 | Need | Use |
-|---|---|
+| --- | --- |
 | Plain rows, system look, selection, swipe actions | `List` |
 | Tabular data, sortable columns, multi-select, column customization | `Table` |
 | Custom row layouts that don't need precise selection-emphasis behavior | `ScrollView` + `LazyVStack` |

--- a/macos-expert/references/windows-navigation.md
+++ b/macos-expert/references/windows-navigation.md
@@ -1,32 +1,34 @@
 # Windows and navigation
 
-Use standard macOS containers and navigation patterns before creating custom shells.
+Use standard macOS containers and navigation patterns before creating custom shells. Match the scene type to the workflow, not the other way around.
 
 ## Choose the right top-level structure
 
-- Use **`WindowGroup`** for standard app windows
-- Use **`DocumentGroup`** for document-based apps
-- Use **`Settings`** for preferences
-- Use **`MenuBarExtra`** for menu bar utilities
-- Use **secondary windows** for inspectors, previews, dashboards, or editors when they are truly separate workspaces
+- `WindowGroup` — the user can open multiple instances of this window (browse-style, multi-document editor, multi-room chat)
+- `Window` (singular, macOS 13.0+) — a single-instance main window. Use this when the app conceptually has *one* main window (most utilities, most "iOS app on Mac" ports, most browser-like content apps)
+- `DocumentGroup` — the app is genuinely document-based and benefits from `NSDocument`-style behavior (open recent, autosave, version browser, file-tied lifecycle)
+- `Settings` — preferences. Auto-binds ⌘, and lives in the app menu
+- `MenuBarExtra` — menu bar utility (macOS 13.0+). Pair with `LSUIElement = true` in Info.plist for menu-bar-only apps. Use `.menuBarExtraStyle(.window)` for popover-like content panels
+- Secondary `Window` or `WindowGroup` scenes — inspectors, dashboards, or genuinely separate workspaces. Don't use auxiliary windows for dialog-sized tasks; use sheets, popovers, or inspectors
 
 ## Window behavior
 
-- Support resizing gracefully; do not hard-code a single usable size unless the app is genuinely fixed-purpose
-- Preserve useful state such as selection, sidebar visibility, and inspector visibility
-- Use full-screen support where it helps sustained work, not as a substitute for window design
+- Support resizing gracefully; don't hard-code a single usable size unless the app is genuinely fixed-purpose
+- Use `.windowResizability(.contentSize)` only when content really should drive the window dimensions
+- Preserve useful state: selection, sidebar visibility, inspector visibility, scroll position. `@SceneStorage` is the right primitive for per-scene state restoration
+- Use full-screen support where it benefits sustained work, not as a substitute for window design
 - Support multiple windows when users may compare, edit, or monitor more than one item at once
 
 ## Toolbars
 
-Toolbars should expose the actions users need often, not every action the app has.
+Toolbars expose actions users need often, not every action the app has.
 
 Good toolbar content:
 
-- Sidebar toggle
-- Search
+- Sidebar toggle (added automatically by `NavigationSplitView` on macOS — remove with `.toolbar(removing: .sidebarToggle)` if you need clean control; `.toolbar(removing:)` requires macOS 14+)
+- Search (or use `.searchable` which lives in the right toolbar slot)
 - View mode or filter controls
-- Primary actions like add, share, or refresh
+- Primary actions: add, share, refresh
 - Inspector toggle when relevant
 
 Avoid:
@@ -35,50 +37,84 @@ Avoid:
 - Duplicating a dense toolbar and a dense inline action bar
 - Replacing standard toolbar placements with arbitrary custom ordering
 
+### SwiftUI toolbar placement is non-deterministic by design
+
+Apple's `ToolbarItemPlacement` documentation states this directly: "SwiftUI determines the appropriate placement for the item based on this intent and its surrounding context, like the current platform." It also warns: "If not all items fit in the available space, an overflow menu may be created and remaining items placed in that menu."
+
+Implications:
+
+- Semantic placements (`.primaryAction`, `.secondaryAction`, `.principal`, `.automatic`, `.status`) are *intents*, not commands. SwiftUI decides the actual location per platform and per layout context
+- Three-pane layouts (`NavigationSplitView` with content + detail) are particularly hard to predict
+- There is no SwiftUI analogue to `NSToolbarDelegate.toolbarAllowedItemIdentifiers` / `toolbarDefaultItemIdentifiers` — no way to declare an explicit identifier list, allow user customization via the standard sheet, or control overflow rules
+- Tracking separators between split-view columns require `NSTrackingSeparatorToolbarItem`, which has no SwiftUI counterpart
+
+Use `NSToolbar` (host the window in AppKit, embed SwiftUI inside toolbar items via `NSHostingView` if needed) when any of these matter:
+
+- Exact item ordering
+- Customization sheet behavior
+- Tracking separators
+- Overflow control
+- Search-field placement that must follow column boundaries
+
+For most apps, SwiftUI's toolbar is fine. Reach for AppKit's toolbar deliberately, not as a default.
+
 ## Navigation patterns
 
 ### Sidebar and content
 
 Prefer split-view patterns for hierarchical or list/detail apps:
 
-- Two-column for list/detail or source/detail
-- Three-column when there is a meaningful intermediate level
+- Two-column for list/detail or source/detail (`NavigationSplitView { sidebar } detail: { … }`)
+- Three-column when there is a meaningful intermediate level (`NavigationSplitView { sidebar } content: { … } detail: { … }`)
 
-Use tabs only when sections are true peers and do not benefit from a shared sidebar.
+Use tabs only when sections are true peers and don't benefit from a shared sidebar. On macOS, tabs feel iOS-y unless they're inside a content view that genuinely has tabbed sub-sections (e.g. a debugger pane).
 
-### Sheets, popovers, and inspectors
+### `NavigationSplitView` notes
 
-- Use **sheets** for focused tasks that block progress in the current window
-- Use **popovers** for lightweight, contextual controls
-- Use **inspectors** for persistent secondary details that should stay available while the user works
+- macOS 13.0+
+- Auto-adds a sidebar toggle toolbar item; remove via `.toolbar(removing: .sidebarToggle)`
+- Column widths via `.navigationSplitViewColumnWidth(_:)` or `.navigationSplitViewColumnWidth(min:ideal:max:)`
+- Style via `.navigationSplitViewStyle(.balanced)` or `.prominentDetail` if the visual emphasis matters
+- Programmatic visibility via `NavigationSplitViewVisibility` binding
+- Compact-class collapse behavior: SwiftUI auto-stacks columns; on iPad in Slide Over the table inside hides headers and additional columns. macOS doesn't hit this path
+
+### Sheets, popovers, inspectors
+
+- Sheets for focused tasks that block progress in the current window
+- Popovers for lightweight contextual controls
+- `.inspector(isPresented:content:)` (macOS 14.0+) for persistent secondary details that stay available while the user works
 
 ## SwiftUI defaults
 
-- `NavigationSplitView`
-- `WindowGroup`, `Window`, `Settings`, `DocumentGroup`
-- `.toolbar`, `.toolbarRole`, `.defaultSize`, `.windowToolbarStyle`
-- `.searchable` for standard in-window search where search is a primary workflow
-- `openWindow(id:)` when auxiliary windows are appropriate
+- `NavigationSplitView` for split layouts
+- `WindowGroup`, `Window`, `Settings`, `DocumentGroup`, `MenuBarExtra` for scenes
+- `.toolbar`, `.toolbarRole(.editor)`/`.browser`, `.defaultSize`, `.windowResizability`, `.windowToolbarStyle`
+- `.searchable` for in-window search
+- `.inspector` for persistent secondary panes
+- `openWindow(id:value:)` from the environment when auxiliary windows make sense
 
 ## AppKit defaults
 
 - `NSWindow` and `NSWindowController`
-- `NSToolbar`
-- `NSSplitViewController`
-- `NSPanel` for utility-style supporting windows
+- `NSToolbar`, `NSToolbarItem`, `NSToolbarDelegate`, `NSTrackingSeparatorToolbarItem`, `NSSearchToolbarItem`
+- `NSSplitViewController` and `NSSplitViewItem` for column behavior with persisted holding priorities and collapse animations
+- `NSPanel` for utility-style supporting windows (HUD-style if appropriate)
 - `NSPopover` for transient contextual UI
+- `NSTitlebarAccessoryViewController` for title-bar accessory views
 
 ## Review checklist
 
-- Window titles and hierarchy are clear
+- Window titles, scene types, and hierarchy match how the user thinks about the app
 - The main action areas are reachable from toolbar or standard controls
-- The app uses sidebars and inspectors where macOS users expect them
-- Full-screen is supported sensibly for content-heavy tasks
+- Sidebars, inspectors, and split-view conventions are used where Mac users expect them
+- Full-screen behaves sensibly for content-heavy tasks
 - Auxiliary windows exist only when they represent a real separate workspace
+- Toolbar layout requirements (deterministic, customizable, with tracking separators) drive the choice between SwiftUI's `.toolbar` and `NSToolbar`
+- State restoration is wired (`@SceneStorage`, AppKit `NSWindow.restorationClass`)
 
 ## Pair this file with
 
 - `designing-for-macos.md` for broader macOS product and UX expectations
 - `menus-commands-input.md` for toolbar actions, commands, and shortcuts
-- `swiftui-macos.md` for SwiftUI scene and navigation API patterns
-- `appkit-and-bridging.md` for AppKit window and split-view details
+- `swiftui-macos.md` for SwiftUI scene and navigation API patterns and known gaps
+- `appkit-and-bridging.md` for AppKit window, toolbar, and split-view details and bridging


### PR DESCRIPTION
## Summary

- Rewrite all eleven `macos-expert` files to honestly reflect what SwiftUI on macOS does and does not do today.
- Add a Shape A (SwiftUI-only) vs Shape B (AppKit shell with hosted SwiftUI) triage rubric near the top of `SKILL.md` so agents pick the right architecture before writing code.
- Name the concrete documented SwiftUI gaps (context-menu state, drag-source lifecycle, `onMoveCommand` iOS gap, `TextField` arrow-key swallow, `ToolbarItemPlacement` non-determinism, `backgroundProminence` `List`/`Table`-only) and point at the AppKit primitive that fills each gap.
- Quote Apple's own documentation verbatim where the gap is non-obvious (`ToolbarItemPlacement`'s "SwiftUI determines the appropriate placement…", `backgroundProminence`'s "Views like List and Table will automatically update…", etc.).
- Verify every named API, modifier, class, and "Available on" line against current Apple docs via the sosumi MCP. Fixed one wrong class name (`NSWindowAccessoryViewController` → `NSTitlebarAccessoryViewController`) and added availability notes for `.toolbar(removing:)`, `.alternatingRowBackgrounds`, and `.contentMargins` (all macOS 14+).

## Why

The previous version was technically accurate but uniformly optimistic about SwiftUI on macOS. It listed `.contextMenu`, `.draggable`, `@FocusState`, and `.toolbar` as "Mac-specific affordances" without acknowledging that Apple's own documentation describes concrete gaps in each of them. That framing led agents (and humans reading the skill) toward Shape A architectures for apps that needed Shape B affordances, and then into custom workarounds for documented platform limitations.

This rewrite keeps the skill grounded in Apple's HIG and developer docs as the source of truth, but is direct about where SwiftUI runs out of road on Mac and which AppKit primitive solves it. The Shape A vs Shape B triage is the single highest-leverage addition: most macOS app decisions follow from that one architectural call, and getting it wrong is expensive.

## Test plan

- [x] All API names, modifiers, classes, and macOS availability lines verified against current Apple docs via sosumi
- [x] `agentskills validate macos-expert` passes locally (after fixing the stale `.venv` shebang from the repo move)
- [x] markdownlint, lychee, typos, and pre-commit hooks pass
- [x] Skill structure preserved: same eleven files, same `Pair this file with` cross-reference pattern, same `SKILL.md` shape