### PR TITLE
git-spice skill: refresh for v0.28.0 (fork mode, v0.26.x notes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .venv/
+.claude/
+.serena/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Repo Is
+
+A collection of [agent skills](https://skills.sh/) — LLM-optimized instruction sets for AI agents. Each top-level directory containing a `SKILL.md` file is a skill. Skills are markdown-based with optional `references/` subdirectories for supporting material.
+
+## Commands
+
+```bash
+# Install dependencies (Python 3.14+, uv required)
+uv sync --locked --group dev
+
+# Validate all skills against the Agent Skills spec
+uv run python scripts/validate_skills.py
+
+# Run all pre-push checks (validation + typos + markdown lint)
+prek run --all-files agentskills-validate typos markdownlint
+
+# Run full pre-push suite including link checking
+prek run --all-files
+
+# Scaffold a new skill
+skills init <name>
+```
+
+## Skill Discovery
+
+Skills are auto-discovered by `scripts/validate_skills.py`: any top-level directory (not starting with `.`) that contains a `SKILL.md` file is treated as a skill. Each `SKILL.md` must have YAML frontmatter with `name` and `description` fields.
+
+## Hook Setup
+
+This repo uses `prek` (Rust-based git hook framework). `prek install` installs only `pre-push` by default to avoid conflicting with GitButler's `pre-commit` hook. The `.git/hooks/pre-commit` is a local wrapper that chains GitButler's hook with prek — don't overwrite it.
+
+## CI
+
+GitHub Actions runs on PR and push to main: syncs deps, then runs `prek` with `agentskills-validate typos markdownlint`. The `lychee` link checker is configured in `prek.toml` but not run in CI.
+
+## Adding a New Skill
+
+1. `skills init <name>` — creates `<name>/SKILL.md` with starter frontmatter
+2. Replace the generated `SKILL.md` with real content
+3. Add any `references/` or supporting files
+4. Run `uv run python scripts/validate_skills.py` and `prek run --all-files`
+5. Commit in small, reviewable steps

--- a/git-spice/README.md
+++ b/git-spice/README.md
@@ -11,7 +11,7 @@ Covers setup, staging rules, daily workflows, submitting, amending, syncing, and
 The skill covers 10 areas:
 
 1. **Before you start** — consult `git-spice -h` generously
-2. **One-time setup** — `git-spice repo init`, forge config, auth
+2. **One-time setup** — `git-spice repo init`, forge config, auth, fork-mode workflows (v0.28.0+)
 3. **Core concepts** — branch, stack, trunk, submit
 4. **Staging rules** — the most common source of mistakes
 5. **Daily workflow** — creating branches, adding commits, navigating the stack

--- a/git-spice/SKILL.md
+++ b/git-spice/SKILL.md
@@ -59,6 +59,30 @@ git-spice auth login --forge=bitbucket
 
 > **Note:** Bitbucket Cloud does not support PR labels, PR assignees, or template enumeration.
 
+**v0.26.1 behavior change:** git-spice no longer falls back to Git Credential Manager-managed credentials automatically. If a previously-working setup suddenly prompts for auth, run `git-spice auth login` (and pick the GCM method explicitly if that's what you used before).
+
+**Headless / no system keychain?** Select the secret storage backend explicitly to skip the keychain probe (v0.26.0+): set `spice.secret.backend` via `git config` or the `GIT_SPICE_SECRET_BACKEND` environment variable. Check `git-spice auth login -h` and the docs for valid backend names.
+
+#### Fork mode (v0.28.0+)
+
+To contribute to a repo you don't have write access to, point `--upstream` at the project repo and `--remote` at your fork:
+
+```bash
+git-spice repo init --trunk main --upstream upstream --remote origin
+```
+
+In fork mode:
+
+- Branch pushes go to the **push** remote (`--remote`, typically your fork)
+- Change Requests are opened against the **upstream** remote (`--upstream`)
+- `git-spice repo sync` pulls trunk from `upstream`
+- Only trunk-based branches get CRs against upstream; stacked branches whose base isn't trunk are still pushed to your fork as part of the stack
+
+**Caveats:**
+
+- GitHub App authentication is **incompatible** with fork mode — use a Personal Access Token instead.
+- The repository storage format upgrades when fork mode is enabled, and **older git-spice versions cannot open the repo afterward**. Make sure collaborators are on v0.28.0+ before flipping a shared repo into fork mode.
+
 ### 3. Core concepts
 
 - **Branch**: a single node in the stack, backed by a Git branch
@@ -100,7 +124,10 @@ Additional `branch create` flags:
 
 ```bash
 git-spice cc -a -m "feat: additional work"   # commit to current branch, auto-restacks upstack
+git-spice cc -a -F path/to/message.txt       # read message from a file (v0.26.0+, also on bc/ca)
 ```
+
+Pass `-F`/`--message-file` instead of `-m` to read the commit message from a file — useful for multi-line or generated messages.
 
 #### Navigate and inspect the stack
 

--- a/prek.toml
+++ b/prek.toml
@@ -9,36 +9,60 @@ default_install_hook_types = ["pre-push"]
 [[repos]]
 repo = "builtin"
 hooks = [
-    { id = "trailing-whitespace", priority = 0 },
-    { id = "end-of-file-fixer", priority = 0 },
-    { id = "check-added-large-files", args = ["--maxkb=1024"], priority = 0 },
-    { id = "check-case-conflict", priority = 0 },
-    { id = "check-merge-conflict", priority = 0 },
-    { id = "check-toml", priority = 0 },
-    { id = "check-json", priority = 0 },
-    { id = "check-yaml", priority = 0 },
-    { id = "check-symlinks", priority = 0 },
-    { id = "mixed-line-ending", args = ["--fix=lf"], priority = 0 },
-    { id = "detect-private-key", priority = 0 },
+  { id = "trailing-whitespace", priority = 0 },
+  { id = "end-of-file-fixer", priority = 0 },
+  { id = "check-added-large-files", args = ["--maxkb=1024"], priority = 0 },
+  { id = "check-case-conflict", priority = 0 },
+  { id = "check-merge-conflict", priority = 0 },
+  { id = "check-toml", priority = 0 },
+  { id = "check-json", priority = 0 },
+  { id = "check-yaml", priority = 0 },
+  { id = "check-symlinks", priority = 0 },
+  { id = "mixed-line-ending", args = ["--fix=lf"], priority = 0 },
+  { id = "detect-private-key", priority = 0 },
 ]
 
 [[repos]]
 repo = "https://github.com/crate-ci/typos"
-rev = "v1.44.0"  # prek autoupdate will fill this
+rev = "v1.46.1"  # prek autoupdate will fill this
 hooks = [{ id = "typos", priority = 1, stages = ["pre-push"] }]
 
 [[repos]]
 repo = "local"
 hooks = [
-    { id = "agentskills-validate", name = "Validate Agent Skills spec", language = "system", entry = "uv run python scripts/validate_skills.py", pass_filenames = false, always_run = true, stages = ["pre-push"], priority = 1 },
+  {
+    id = "agentskills-validate",
+    name = "Validate Agent Skills spec",
+    language = "system",
+    entry = "uv run python scripts/validate_skills.py",
+    pass_filenames = false,
+    always_run = true,
+    stages = ["pre-push"],
+    priority = 1
+  },
 ]
 
 [[repos]]
 repo = "https://github.com/igorshubovych/markdownlint-cli"
 rev = "v0.48.0"
-hooks = [{ id = "markdownlint", priority = 1, stages = ["pre-push"], types_or = ["markdown"] }]
+hooks = [
+  {
+    id = "markdownlint",
+    priority = 1,
+    stages = ["pre-push"],
+    types_or = ["markdown"]
+  }
+]
 
 [[repos]]
 repo = "https://github.com/lycheeverse/lychee"
-rev = "lychee-v0.23.0"  # lychee tags nightly as latest; prek autoupdate may switch to it
-hooks = [{ id = "lychee", args = ["--no-progress"], priority = 1, stages = ["pre-push"], types_or = ["markdown"] }]
+rev = "lychee-v0.24.2"  # lychee tags nightly as latest; prek autoupdate may switch to it
+hooks = [
+  {
+    id = "lychee",
+    args = ["--no-progress"],
+    priority = 1,
+    stages = ["pre-push"],
+    types_or = ["markdown"]
+  }
+]


### PR DESCRIPTION
## Summary

- New **Fork mode (v0.28.0+)** subsection in setup: `--upstream`/`--remote` usage, submission/sync behavior, plus the GitHub-App-incompatible and storage-format caveats.
- Added the v0.26.1 GCM auto-fallback removal note in the auth section (common surprise: previously-working credentials now require an explicit `git-spice auth login`).
- Added a `spice.secret.backend` / `GIT_SPICE_SECRET_BACKEND` hint for headless or no-keychain environments (v0.26.0+).
- Added `-F`/`--message-file` to the daily-workflow commit examples (v0.26.0+).
- README section list mentions fork-mode workflows.

## Why

Skill was last updated for v0.25.0. Three releases shipped since — v0.26.0, v0.26.1, v0.27.0, and v0.28.0 — and the v0.28.0 fork-mode workflow is a whole new submission model that wasn't covered. The v0.26.1 GCM behavior change is a silent breaker for users who relied on automatic credential fallback (notably self-hosted GitLab over GCM), worth flagging as a note rather than letting agents rediscover it.

v0.27.0 is mostly distro packaging and a minor `branch split` UX tweak — nothing skill-relevant, so it isn't mentioned.

## Test plan

- [x] `uv run python scripts/validate_skills.py` passes
- [x] `prek run typos --files git-spice/SKILL.md git-spice/README.md` passes
- [x] `prek run markdownlint --files git-spice/SKILL.md git-spice/README.md` passes
- [x] `prek run agentskills-validate --all-files` passes
- [ ] Sanity-check the new fork-mode subsection against `git-spice repo init -h` output on v0.28.0

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh git-spice skill documentation for fork mode and v0.26.x changes
> - Updates [git-spice/SKILL.md](https://github.com/detailobsessed/agent-skills/pull/11/files#diff-07583d52b047fb2b5d1dfbd3b896ffe15c0e04ec7d56cd1fb314b9b5e8063af1) with a new 'Fork mode (v0.28.0+)' section covering upstream/remote setup, behavior differences, and caveats (GitHub App auth incompatibility, repository format upgrade).
> - Documents v0.26.1 credential fallback change: `gs` no longer automatically falls back to Git Credential Manager; users must re-run `auth login`.
> - Adds guidance for specifying a secret storage backend in headless environments and documents the `-F/--message-file` flag (v0.26.0+).
> - Bumps pre-push hook tool versions: `typos` to v1.46.1 and `lychee` to v0.24.2 in [prek.toml](https://github.com/detailobsessed/agent-skills/pull/11/files#diff-72359463e1c50ddcb8dfabe900898a8f1d92416bbe6754f2e497f62d96232021).
> - Adds [CLAUDE.md](https://github.com/detailobsessed/agent-skills/pull/11/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7) with a repository guide for Claude Code covering skill discovery, hook setup, and instructions for adding new skills.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f294d5a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->