### PR TITLE
chore(tooling): wire ruff and ty into pre-push hooks and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Run prek hooks
         uses: j178/prek-action@0bb87d7f00b0c99306c8bcb8b8beba1eb581c037 # v1.1.1
         with:
-          extra-args: "--all-files agentskills-validate typos markdownlint"
+          extra-args: "--all-files agentskills-validate typos markdownlint ruff-check ruff-format ty"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,8 @@ uv sync --locked --group dev
 # Validate all skills against the Agent Skills spec
 uv run python scripts/validate_skills.py
 
-# Run all pre-push checks (validation + typos + markdown lint)
-prek run --all-files agentskills-validate typos markdownlint
+# Run all pre-push checks (validation + typos + markdown lint + python lint/type)
+prek run --all-files agentskills-validate typos markdownlint ruff-check ruff-format ty
 
 # Run full pre-push suite including link checking
 prek run --all-files
@@ -35,7 +35,7 @@ This repo uses `prek` (Rust-based git hook framework). `prek install` installs o
 
 ## CI
 
-GitHub Actions runs on PR and push to main: syncs deps, then runs `prek` with `agentskills-validate typos markdownlint`. The `lychee` link checker is configured in `prek.toml` but not run in CI.
+GitHub Actions runs on PR and push to main: syncs deps, then runs `prek` with `agentskills-validate typos markdownlint ruff-check ruff-format ty`. The `lychee` link checker is configured in `prek.toml` but not run in CI.
 
 ## Adding a New Skill
 

--- a/prek.toml
+++ b/prek.toml
@@ -28,6 +28,14 @@ rev = "v1.46.1"  # prek autoupdate will fill this
 hooks = [{ id = "typos", priority = 1, stages = ["pre-push"] }]
 
 [[repos]]
+repo = "https://github.com/astral-sh/ruff-pre-commit"
+rev = "v0.15.13"
+hooks = [
+  { id = "ruff-check", priority = 1, stages = ["pre-push"] },
+  { id = "ruff-format", args = ["--check"], priority = 1, stages = ["pre-push"] },
+]
+
+[[repos]]
 repo = "local"
 hooks = [
   {
@@ -35,6 +43,16 @@ hooks = [
     name = "Validate Agent Skills spec",
     language = "system",
     entry = "uv run python scripts/validate_skills.py",
+    pass_filenames = false,
+    always_run = true,
+    stages = ["pre-push"],
+    priority = 1
+  },
+  {
+    id = "ty",
+    name = "Type-check with ty",
+    language = "system",
+    entry = "uvx ty check .",
     pass_filenames = false,
     always_run = true,
     stages = ["pre-push"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,10 @@ dev = [
     "prek>=0.3.4,<0.4",
     "skills-ref>=0.1.1",
 ]
+
+[tool.ruff]
+target-version = "py314"
+line-length = 100
+
+[tool.ty.environment]
+python-version = "3.14"

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -1,42 +1,515 @@
+"""Validate every skill in this repo against the Agent Skills spec.
+
+Sources of truth:
+    https://agentskills.io/specification
+    https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices
+
+The baseline (frontmatter regex, reserved-word check, name length) is delegated
+to `agentskills validate`. This script layers on the structural and content
+checks that the upstream CLI does not perform.
+"""
+
 from __future__ import annotations
 
+import json
+import os
+import re
 import subprocess
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
+# Limits drawn directly from the spec / best-practices docs. The numbers are
+# not invented here — adjust the URL and rationale together if they change.
+MAX_BODY_LINES = 500  # "Keep your main SKILL.md under 500 lines"
+MAX_BODY_WORDS = (
+    5000  # "<5000 tokens recommended" (1 token ~= 1 word for English prose)
+)
+MAX_DESCRIPTION_LEN = 1024  # spec MUST
+MAX_NAME_LEN = 64  # spec MUST
+MAX_COMPATIBILITY_LEN = 500  # spec MUST when present
+REFERENCE_TOC_THRESHOLD_LINES = 100  # best-practices: TOC recommended past this
+KNOWN_SUBDIRS = {"references", "scripts", "assets"}  # spec-named optional dirs
+NAME_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+RESERVED_NAME_WORDS = {"anthropic", "claude"}  # best-practices: "reserved words"
+# A description that opens in first/second person fails the third-person rule.
+FIRST_OR_SECOND_PERSON_RE = re.compile(
+    r"^\s*(I\b|I'm\b|I can\b|My\b|We\b|Our\b|You\b|Your\b)", re.IGNORECASE
+)
+# Trigger phrase: discovery hinges on this per best-practices.
+TRIGGER_PHRASE_RE = re.compile(
+    r"\b(use\s+when|use\s+this\s+(skill\s+)?when|invoke\s+when|when\s+the\s+user)\b",
+    re.IGNORECASE,
+)
+# Time-sensitive phrasing: dates that will go stale without a fallback. Months
+# and quarters as anchors; flagged unless explicitly inside an "old patterns"
+# / `<details>` block (we don't try to detect that — false positive risk is
+# acceptable and the warning prompts a human check).
+TIME_SENSITIVE_RE = re.compile(
+    r"\b(before|after|by|until|since|as of)\s+"
+    r"(January|February|March|April|May|June|July|August|"
+    r"September|October|November|December|Q[1-4])\b",
+    re.IGNORECASE,
+)
+# Windows-style backslash paths in markdown link targets or inline code. Skip
+# escaped backslashes in regex examples — we only flag look-alike file paths.
+WINDOWS_PATH_RE = re.compile(r"[A-Za-z0-9_.-]+\\[A-Za-z0-9_.-]+\.[A-Za-z0-9]+")
+# Markdown link target: [text](target) where target is a relative path.
+MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)\s#]+(?:#[^\s)]*)?)\)")
 
-def get_skill_directories() -> list[str]:
+
+@dataclass(frozen=True)
+class Finding:
+    severity: str  # "error" or "warning"
+    code: str  # short slug, e.g. "body-too-long"
+    message: str
+    spec_ref: str  # which spec / best-practices section
+    location: str = ""  # optional "path:line" or path
+
+
+def _split_frontmatter(text: str) -> tuple[str, str]:
+    """Split a SKILL.md into (frontmatter_yaml, body_markdown).
+
+    Returns ("", text) if no frontmatter delimiters are present — caller can
+    treat that as a spec violation.
+    """
+    if not text.startswith("---\n"):
+        return "", text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return "", text
+    return text[4:end], text[end + len("\n---\n") :]
+
+
+def _line_of(text: str, needle_match: re.Match[str]) -> int:
+    """1-based line number of a regex match in `text`."""
+    return text.count("\n", 0, needle_match.start()) + 1
+
+
+def _read_properties(skill_dir: Path) -> dict[str, object] | None:
+    """Use `agentskills read-properties` to parse frontmatter without adding a
+    YAML dependency. Returns None if the CLI itself errors (caller will already
+    have a baseline failure from `agentskills validate`)."""
+    try:
+        result = subprocess.run(
+            ["uv", "run", "agentskills", "read-properties", skill_dir.name],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+# --- individual checks --------------------------------------------------------
+
+
+def check_baseline(skill_dir: Path) -> list[Finding]:
+    """Defer name/description regex + reserved words to upstream `agentskills`.
+    We only surface its exit status here; the CLI prints its own diagnostics.
+    """
+    result = subprocess.run(
+        ["uv", "run", "agentskills", "validate", skill_dir.name],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        return []
+    detail = (result.stdout + result.stderr).strip() or "(no detail)"
+    return [
+        Finding(
+            "error",
+            "baseline-failed",
+            f"`agentskills validate` rejected this skill:\n{detail}",
+            "agentskills.io/specification#frontmatter",
+        )
+    ]
+
+
+def check_directory_name_matches(
+    skill_dir: Path, props: dict[str, object]
+) -> list[Finding]:
+    """Spec MUST: `name` field must match the parent directory name."""
+    name = props.get("name")
+    if not isinstance(name, str):
+        return []  # baseline already errored
+    if name != skill_dir.name:
+        return [
+            Finding(
+                "error",
+                "name-dir-mismatch",
+                f"frontmatter name={name!r} does not match directory name {skill_dir.name!r}",
+                "agentskills.io/specification#name-field",
+                location=f"{skill_dir.name}/SKILL.md",
+            )
+        ]
+    return []
+
+
+def check_body_length(skill_dir: Path, body: str) -> list[Finding]:
+    """Spec recommendation: body under 500 lines and ~5000 tokens."""
+    findings: list[Finding] = []
+    body_lines = body.count("\n") + (0 if body.endswith("\n") else 1)
+    if body_lines > MAX_BODY_LINES:
+        findings.append(
+            Finding(
+                "error",
+                "body-too-many-lines",
+                f"SKILL.md body is {body_lines} lines; spec recommends ≤ {MAX_BODY_LINES}. "
+                f"Split detail into references/*.md.",
+                "agentskills.io/specification#progressive-disclosure",
+                location=f"{skill_dir.name}/SKILL.md",
+            )
+        )
+    word_count = len(body.split())
+    if word_count > MAX_BODY_WORDS:
+        findings.append(
+            Finding(
+                "error",
+                "body-too-many-words",
+                f"SKILL.md body is {word_count} words; spec recommends ≤ {MAX_BODY_WORDS} "
+                f"(roughly 5000 tokens).",
+                "agentskills.io/specification#progressive-disclosure",
+                location=f"{skill_dir.name}/SKILL.md",
+            )
+        )
+    return findings
+
+
+def check_description_quality(
+    skill_dir: Path, props: dict[str, object]
+) -> list[Finding]:
+    """Best-practices: third-person voice, contains a `Use when` trigger."""
+    desc = props.get("description")
+    if not isinstance(desc, str):
+        return []
+    findings: list[Finding] = []
+    if FIRST_OR_SECOND_PERSON_RE.match(desc):
+        findings.append(
+            Finding(
+                "error",
+                "description-not-third-person",
+                "description must be written in third person; opens with first/second-person "
+                "voice. See the <Warning> block in the best-practices doc.",
+                "platform.claude.com/.../best-practices#writing-effective-descriptions",
+                location=f"{skill_dir.name}/SKILL.md",
+            )
+        )
+    if not TRIGGER_PHRASE_RE.search(desc):
+        findings.append(
+            Finding(
+                "error",
+                "description-no-trigger-phrase",
+                "description should include a 'Use when' / 'Invoke when' / 'when the user' trigger "
+                "phrase — this is the primary mechanism agents use to discover the skill.",
+                "platform.claude.com/.../best-practices#writing-effective-descriptions",
+                location=f"{skill_dir.name}/SKILL.md",
+            )
+        )
+    if len(desc) > MAX_DESCRIPTION_LEN:
+        findings.append(
+            Finding(
+                "error",
+                "description-too-long",
+                f"description is {len(desc)} chars; spec maximum is {MAX_DESCRIPTION_LEN}.",
+                "agentskills.io/specification#description-field",
+                location=f"{skill_dir.name}/SKILL.md",
+            )
+        )
+    return findings
+
+
+def check_optional_fields(skill_dir: Path, props: dict[str, object]) -> list[Finding]:
+    """Validate optional frontmatter fields when present."""
+    findings: list[Finding] = []
+    compat = props.get("compatibility")
+    if isinstance(compat, str) and len(compat) > MAX_COMPATIBILITY_LEN:
+        findings.append(
+            Finding(
+                "error",
+                "compatibility-too-long",
+                f"compatibility is {len(compat)} chars; spec maximum is {MAX_COMPATIBILITY_LEN}.",
+                "agentskills.io/specification#compatibility-field",
+                location=f"{skill_dir.name}/SKILL.md",
+            )
+        )
+    return findings
+
+
+def check_subdirectories(skill_dir: Path) -> list[Finding]:
+    """Warn on subdirectories outside the spec-named set."""
+    findings: list[Finding] = []
+    for entry in sorted(skill_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        if entry.name.startswith("."):
+            continue
+        if entry.name in KNOWN_SUBDIRS:
+            continue
+        findings.append(
+            Finding(
+                "warning",
+                "unexpected-subdirectory",
+                f"unrecognized top-level subdirectory '{entry.name}/' — spec names "
+                f"references/, scripts/, assets/. Other dirs are allowed but easy to miss.",
+                "agentskills.io/specification#directory-structure",
+                location=f"{skill_dir.name}/{entry.name}/",
+            )
+        )
+    return findings
+
+
+def check_markdown_paths(skill_dir: Path, skill_md_text: str) -> list[Finding]:
+    """No Windows backslash paths in markdown content."""
+    findings: list[Finding] = []
+    for match in WINDOWS_PATH_RE.finditer(skill_md_text):
+        line = _line_of(skill_md_text, match)
+        findings.append(
+            Finding(
+                "error",
+                "windows-path",
+                f"Windows-style backslash path '{match.group(0)}' — use forward slashes only.",
+                "platform.claude.com/.../best-practices#avoid-windows-style-paths",
+                location=f"{skill_dir.name}/SKILL.md:{line}",
+            )
+        )
+    return findings
+
+
+def check_reference_links(skill_dir: Path, skill_md_text: str) -> list[Finding]:
+    """Every relative markdown link from SKILL.md must resolve, and references
+    must stay one level deep per best-practices."""
+    findings: list[Finding] = []
+    for match in MARKDOWN_LINK_RE.finditer(skill_md_text):
+        target = match.group(1)
+        if target.startswith(("http://", "https://", "mailto:", "#")):
+            continue
+        # Strip any anchor.
+        path_part = target.split("#", 1)[0]
+        if not path_part:
+            continue
+        target_path = (skill_dir / path_part).resolve()
+        # Confine to the skill dir; the spec uses relative paths from skill root.
+        try:
+            target_path.relative_to(skill_dir.resolve())
+        except ValueError:
+            findings.append(
+                Finding(
+                    "error",
+                    "link-escapes-skill",
+                    f"markdown link '{target}' escapes the skill directory.",
+                    "agentskills.io/specification#file-references",
+                    location=f"{skill_dir.name}/SKILL.md:{_line_of(skill_md_text, match)}",
+                )
+            )
+            continue
+        if not target_path.exists():
+            findings.append(
+                Finding(
+                    "error",
+                    "broken-link",
+                    f"markdown link '{target}' points to a nonexistent file.",
+                    "agentskills.io/specification#file-references",
+                    location=f"{skill_dir.name}/SKILL.md:{_line_of(skill_md_text, match)}",
+                )
+            )
+            continue
+        # Depth check: relative path should be at most two segments
+        # (e.g. references/foo.md is fine; references/sub/foo.md is one too deep).
+        rel = target_path.relative_to(skill_dir.resolve())
+        if len(rel.parts) > 2:
+            findings.append(
+                Finding(
+                    "error",
+                    "link-too-deep",
+                    f"reference '{rel}' is more than one directory deep; keep references "
+                    f"one level from SKILL.md per best-practices.",
+                    "platform.claude.com/.../best-practices#avoid-deeply-nested-references",
+                    location=f"{skill_dir.name}/SKILL.md:{_line_of(skill_md_text, match)}",
+                )
+            )
+    return findings
+
+
+def check_reference_tocs(skill_dir: Path) -> list[Finding]:
+    """Reference files >100 lines should include a Table of Contents heading.
+
+    Per best-practices: 'For reference files longer than 100 lines, include a
+    table of contents at the top.'
+    """
+    findings: list[Finding] = []
+    refs_dir = skill_dir / "references"
+    if not refs_dir.is_dir():
+        return findings
+    for ref in sorted(refs_dir.glob("*.md")):
+        text = ref.read_text(encoding="utf-8")
+        line_count = text.count("\n") + 1
+        if line_count <= REFERENCE_TOC_THRESHOLD_LINES:
+            continue
+        # Check the first 30 lines for a TOC heading.
+        head = "\n".join(text.splitlines()[:30]).lower()
+        if "## contents" in head or "## table of contents" in head:
+            continue
+        findings.append(
+            Finding(
+                "warning",
+                "reference-missing-toc",
+                f"{ref.name} is {line_count} lines but has no '## Contents' heading near the top. "
+                f"Agents may use a partial read and miss content past the preview window.",
+                "platform.claude.com/.../best-practices#structure-longer-reference-files",
+                location=f"{skill_dir.name}/references/{ref.name}",
+            )
+        )
+    return findings
+
+
+def check_time_sensitive_phrasing(skill_dir: Path, skill_md_text: str) -> list[Finding]:
+    """Warn (not error) on dated phrasing without a clear historical-context block."""
+    findings: list[Finding] = []
+    for match in TIME_SENSITIVE_RE.finditer(skill_md_text):
+        line = _line_of(skill_md_text, match)
+        findings.append(
+            Finding(
+                "warning",
+                "time-sensitive-phrase",
+                f"time-sensitive phrasing '{match.group(0)}' may go stale. Move dated guidance "
+                f"into an 'Old patterns' / `<details>` block, or rephrase as current-only.",
+                "platform.claude.com/.../best-practices#avoid-time-sensitive-information",
+                location=f"{skill_dir.name}/SKILL.md:{line}",
+            )
+        )
+    return findings
+
+
+def check_reserved_words_in_name(
+    skill_dir: Path, props: dict[str, object]
+) -> list[Finding]:
+    """Best-practices says 'anthropic' and 'claude' are reserved words for the
+    name field. The upstream CLI may already check this; we duplicate for safety.
+    """
+    name = props.get("name")
+    if not isinstance(name, str):
+        return []
+    parts = set(name.split("-"))
+    bad = parts & RESERVED_NAME_WORDS
+    if bad:
+        return [
+            Finding(
+                "error",
+                "reserved-name-word",
+                f"name contains reserved word(s) {sorted(bad)!r} — reserved by Anthropic.",
+                "platform.claude.com/.../best-practices#technical-notes",
+                location=f"{skill_dir.name}/SKILL.md",
+            )
+        ]
+    return []
+
+
+# --- runner -------------------------------------------------------------------
+
+
+def get_skill_directories() -> list[Path]:
     skills = sorted(
-        path.name
+        path
         for path in REPO_ROOT.iterdir()
-        if path.is_dir() and not path.name.startswith(".") and (path / "SKILL.md").is_file()
+        if path.is_dir()
+        and not path.name.startswith(".")
+        and (path / "SKILL.md").is_file()
     )
     if not skills:
         raise SystemExit("No skill directories with SKILL.md were found.")
     return skills
 
 
+def run_all_checks(skill_dir: Path) -> list[Finding]:
+    skill_md = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    _, body = _split_frontmatter(skill_md)
+
+    findings: list[Finding] = []
+    findings.extend(check_baseline(skill_dir))
+
+    props = _read_properties(skill_dir) or {}
+
+    findings.extend(check_directory_name_matches(skill_dir, props))
+    findings.extend(check_reserved_words_in_name(skill_dir, props))
+    findings.extend(check_description_quality(skill_dir, props))
+    findings.extend(check_optional_fields(skill_dir, props))
+    findings.extend(check_body_length(skill_dir, body))
+    findings.extend(check_subdirectories(skill_dir))
+    findings.extend(check_markdown_paths(skill_dir, skill_md))
+    findings.extend(check_reference_links(skill_dir, skill_md))
+    findings.extend(check_reference_tocs(skill_dir))
+    findings.extend(check_time_sensitive_phrasing(skill_dir, skill_md))
+    return findings
+
+
+def _color(s: str, code: str) -> str:
+    if not sys.stdout.isatty() or os.environ.get("NO_COLOR"):
+        return s
+    return f"\033[{code}m{s}\033[0m"
+
+
+def _render_finding(f: Finding) -> str:
+    badge = (
+        _color("ERROR  ", "31") if f.severity == "error" else _color("WARN   ", "33")
+    )
+    loc = f"  {_color(f.location, '36')}" if f.location else ""
+    return (
+        f"  {badge} [{f.code}]{loc}\n"
+        f"    {f.message}\n"
+        f"    spec: {_color(f.spec_ref, '90')}"
+    )
+
+
+def _summary_line(findings: Iterable[Finding]) -> str:
+    errors = sum(1 for f in findings if f.severity == "error")
+    warnings = sum(1 for f in findings if f.severity == "warning")
+    if errors == 0 and warnings == 0:
+        return f"  {_color('PASS', '32')}"
+    parts: list[str] = []
+    if errors:
+        parts.append(_color(f"{errors} error(s)", "31"))
+    if warnings:
+        parts.append(_color(f"{warnings} warning(s)", "33"))
+    return "  " + ", ".join(parts)
+
+
 def main() -> int:
-    failures: list[str] = []
+    total_errors = 0
+    total_warnings = 0
+    for skill_dir in get_skill_directories():
+        print(f"\n== {skill_dir.name} ==")
+        findings = run_all_checks(skill_dir)
+        for f in findings:
+            print(_render_finding(f))
+        print(_summary_line(findings))
+        total_errors += sum(1 for f in findings if f.severity == "error")
+        total_warnings += sum(1 for f in findings if f.severity == "warning")
 
-    for skill in get_skill_directories():
-        print(f"== {skill} ==")
-        result = subprocess.run(
-            ["uv", "run", "agentskills", "validate", skill],
-            cwd=REPO_ROOT,
-            check=False,
+    print()
+    if total_errors:
+        print(
+            _color(
+                f"FAILED: {total_errors} error(s), {total_warnings} warning(s).", "31"
+            )
         )
-        if result.returncode != 0:
-            failures.append(skill)
-
-    if failures:
-        print()
-        print("Validation failed for:")
-        for skill in failures:
-            print(f"- {skill}")
         return 1
-
+    if total_warnings:
+        print(_color(f"OK with {total_warnings} warning(s).", "33"))
+    else:
+        print(_color("All skills passed.", "32"))
     return 0
 
 

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -25,9 +25,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 # Limits drawn directly from the spec / best-practices docs. The numbers are
 # not invented here — adjust the URL and rationale together if they change.
 MAX_BODY_LINES = 500  # "Keep your main SKILL.md under 500 lines"
-MAX_BODY_WORDS = (
-    5000  # "<5000 tokens recommended" (1 token ~= 1 word for English prose)
-)
+MAX_BODY_WORDS = 5000  # "<5000 tokens recommended" (1 token ~= 1 word for English prose)
 MAX_DESCRIPTION_LEN = 1024  # spec MUST
 MAX_NAME_LEN = 64  # spec MUST
 MAX_COMPATIBILITY_LEN = 500  # spec MUST when present
@@ -138,9 +136,7 @@ def check_baseline(skill_dir: Path) -> list[Finding]:
     ]
 
 
-def check_directory_name_matches(
-    skill_dir: Path, props: dict[str, object]
-) -> list[Finding]:
+def check_directory_name_matches(skill_dir: Path, props: dict[str, object]) -> list[Finding]:
     """Spec MUST: `name` field must match the parent directory name."""
     name = props.get("name")
     if not isinstance(name, str):
@@ -188,9 +184,7 @@ def check_body_length(skill_dir: Path, body: str) -> list[Finding]:
     return findings
 
 
-def check_description_quality(
-    skill_dir: Path, props: dict[str, object]
-) -> list[Finding]:
+def check_description_quality(skill_dir: Path, props: dict[str, object]) -> list[Finding]:
     """Best-practices: third-person voice, contains a `Use when` trigger."""
     desc = props.get("description")
     if not isinstance(desc, str):
@@ -393,9 +387,7 @@ def check_time_sensitive_phrasing(skill_dir: Path, skill_md_text: str) -> list[F
     return findings
 
 
-def check_reserved_words_in_name(
-    skill_dir: Path, props: dict[str, object]
-) -> list[Finding]:
+def check_reserved_words_in_name(skill_dir: Path, props: dict[str, object]) -> list[Finding]:
     """Best-practices says 'anthropic' and 'claude' are reserved words for the
     name field. The upstream CLI may already check this; we duplicate for safety.
     """
@@ -424,9 +416,7 @@ def get_skill_directories() -> list[Path]:
     skills = sorted(
         path
         for path in REPO_ROOT.iterdir()
-        if path.is_dir()
-        and not path.name.startswith(".")
-        and (path / "SKILL.md").is_file()
+        if path.is_dir() and not path.name.startswith(".") and (path / "SKILL.md").is_file()
     )
     if not skills:
         raise SystemExit("No skill directories with SKILL.md were found.")
@@ -462,15 +452,9 @@ def _color(s: str, code: str) -> str:
 
 
 def _render_finding(f: Finding) -> str:
-    badge = (
-        _color("ERROR  ", "31") if f.severity == "error" else _color("WARN   ", "33")
-    )
+    badge = _color("ERROR  ", "31") if f.severity == "error" else _color("WARN   ", "33")
     loc = f"  {_color(f.location, '36')}" if f.location else ""
-    return (
-        f"  {badge} [{f.code}]{loc}\n"
-        f"    {f.message}\n"
-        f"    spec: {_color(f.spec_ref, '90')}"
-    )
+    return f"  {badge} [{f.code}]{loc}\n    {f.message}\n    spec: {_color(f.spec_ref, '90')}"
 
 
 def _summary_line(findings: Iterable[Finding]) -> str:
@@ -500,11 +484,7 @@ def main() -> int:
 
     print()
     if total_errors:
-        print(
-            _color(
-                f"FAILED: {total_errors} error(s), {total_warnings} warning(s).", "31"
-            )
-        )
+        print(_color(f"FAILED: {total_errors} error(s), {total_warnings} warning(s).", "31"))
         return 1
     if total_warnings:
         print(_color(f"OK with {total_warnings} warning(s).", "33"))

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -116,13 +116,24 @@ def check_baseline(skill_dir: Path) -> list[Finding]:
     """Defer name/description regex + reserved words to upstream `agentskills`.
     We only surface its exit status here; the CLI prints its own diagnostics.
     """
-    result = subprocess.run(
-        ["uv", "run", "agentskills", "validate", skill_dir.name],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["uv", "run", "agentskills", "validate", skill_dir.name],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return [
+            Finding(
+                "error",
+                "baseline-unavailable",
+                "`uv` was not found on PATH; cannot run `agentskills validate`. "
+                "Install uv (https://docs.astral.sh/uv/) so baseline validation can run.",
+                "agentskills.io/specification#frontmatter",
+            )
+        ]
     if result.returncode == 0:
         return []
     detail = (result.stdout + result.stderr).strip() or "(no detail)"
@@ -349,7 +360,7 @@ def check_reference_tocs(skill_dir: Path) -> list[Finding]:
         return findings
     for ref in sorted(refs_dir.glob("*.md")):
         text = ref.read_text(encoding="utf-8")
-        line_count = text.count("\n") + 1
+        line_count = text.count("\n") + (0 if text.endswith("\n") else 1)
         if line_count <= REFERENCE_TOC_THRESHOLD_LINES:
             continue
         # Check the first 30 lines for a TOC heading.

--- a/step-dev/SKILL.md
+++ b/step-dev/SKILL.md
@@ -36,6 +36,7 @@ These are the building blocks you need to understand before diving into any refe
 Keywords are the fundamental building blocks of Plans. They encapsulate automation logic — anything from a single API call to a full browser-driven workflow. Step integrates natively with Selenium, Cypress, Playwright, Appium, JMeter, K6, and others, but also supports custom keywords in Java, .NET, and JavaScript/TypeScript via the Keyword API.
 
 Key characteristics:
+
 - **Stateless by default** — a new instance is created per execution, released afterward
 - **Stateful via sessions** — share data across keyword executions within a workflow using the session object
 - **Lifecycle hooks** — optional `beforeKeyword`, `afterKeyword`, and `onError` hooks for setup, cleanup, and error handling

--- a/step-dev/SKILL.md
+++ b/step-dev/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: step-dev
+description: Developer guide for the Step unified automation platform. Covers keyword development (Java, .NET, JS/TS), the Keyword API, Automation Packages, the YAML descriptor, Step CLI, Maven plugin, CI/CD integration, and local/remote execution. Use when building, debugging, deploying, or reviewing Step automation code — keywords, plans, packages, or anything involving step.dev, automation-package.yaml, the Step CLI, or the Keyword API. Also use when the user mentions load testing, synthetic monitoring, or RPA in the context of Step.
+---
+
+# Step Developer Guide
+
+Step is a unified automation platform for testing, RPA, CI/CD, load testing, and synthetic monitoring. It lets developers define automation workflows as code alongside application code, package them as self-contained Automation Packages, and execute or deploy them locally or on a Step server.
+
+**Always verify against the latest docs before presenting API details as fact.** Step evolves across versions. The reference files in this skill are based on the v29 documentation. Check the live docs when version-specific behavior matters.
+
+- Documentation: https://step.dev/knowledgebase/
+- Developer guide: https://step.dev/knowledgebase/categories/developer-guide/
+- Tutorials: https://step.dev/tutorials
+- GitHub samples: https://github.com/exense/step-samples
+
+## When to use
+
+- Developing custom keywords in Java, .NET, JavaScript, or TypeScript
+- Writing or editing `automation-package.yaml` descriptors
+- Setting up Automation Packages for load testing, synthetic monitoring, E2E tests, or RPA
+- Using the Step CLI or Maven plugin to execute, deploy, or package automation
+- Integrating Step into a CI/CD pipeline
+- Running automation packages locally with JUnit
+- Working with Step plans, parameters, schedules, or alerting rules
+- Debugging keyword lifecycle issues (hooks, sessions, error handling, measurements)
+- Choosing between stateful and stateless keyword patterns
+- Any time the user mentions Step (step.dev), Keywords, Automation Packages, or the Step CLI
+
+## Core concepts
+
+These are the building blocks you need to understand before diving into any reference file.
+
+### Keywords
+
+Keywords are the fundamental building blocks of Plans. They encapsulate automation logic — anything from a single API call to a full browser-driven workflow. Step integrates natively with Selenium, Cypress, Playwright, Appium, JMeter, K6, and others, but also supports custom keywords in Java, .NET, and JavaScript/TypeScript via the Keyword API.
+
+Key characteristics:
+- **Stateless by default** — a new instance is created per execution, released afterward
+- **Stateful via sessions** — share data across keyword executions within a workflow using the session object
+- **Lifecycle hooks** — optional `beforeKeyword`, `afterKeyword`, and `onError` hooks for setup, cleanup, and error handling
+
+### Automation Packages
+
+An Automation Package is a self-contained bundle of Plans, Keywords, Parameters, Schedules, Resources, and Alerting Rules. Defined declaratively in `automation-package.yaml`, packages can be executed locally, executed remotely in isolation, or deployed to a Step server.
+
+Supported formats: JAR (Java), ZIP, Folder (CLI only), DLL (.NET)
+
+### Plans
+
+Plans define the operational logic — what Step actually executes. They are tree structures composed of controls (sequence, threadGroup, forEach, callKeyword, etc.) and can be defined in YAML, the visual editor, or as plain text.
+
+### Step CLI and Maven plugin
+
+The CLI (`step ap execute`, `step ap deploy`) and Maven plugin handle packaging, local/remote execution, and deployment to Step servers. The CLI works with folders, ZIPs, JARs, and Maven artifact coordinates.
+
+## Load the right references
+
+Read only what you need for the task at hand.
+
+- Read `references/keywords.md` for keyword development concepts, the Keyword API across all languages, inputs/outputs, hooks, sessions, measurements, error handling, and the Keyword Proxy
+  - *Triggers: keyword, AbstractKeyword, @Keyword, keyword API, beforeKeyword, afterKeyword, onError, session, output.add, OutputBuilder, measurements, startMeasure, live reporting, keyword proxy, stateful, stateless*
+
+- Read `references/automation-packages.md` for Automation Package structure, the YAML descriptor syntax, keyword/plan/parameter/schedule/alerting-rule declarations, fragment files, and IDE setup
+  - *Triggers: automation-package.yaml, automation package, YAML descriptor, plans, parameters, schedules, alerting rules, fragments, threadGroup, callKeyword, testScenario, testCase, deploy, package format, JAR layout, ZIP layout*
+
+- Read `references/cli-and-deployment.md` for the Step CLI, Maven plugin, local/remote execution, deployment, CI/CD integration, library management, JUnit integration, and execution parameters
+  - *Triggers: step CLI, step ap execute, step ap deploy, maven plugin, CI/CD, local execution, remote execution, JUnit, StepJUnit5, deploy automation package, execute automation package, stepcli.properties, artifact repository, library, filtering plans*
+
+## Anti-patterns
+
+- Writing keywords that create resources (browsers, connections, file handles) without cleanup — implement cleanup in `afterKeyword` or use try/finally
+- Storing large objects in sessions when stateless keywords would suffice — sessions persist across a workflow group and consume memory
+- Declaring all entities in Java annotations when YAML is cleaner — YAML is language-agnostic and works across all keyword types
+- Hardcoding environment-specific values instead of using Step Parameters with activation scripts
+- Skipping local execution — always test keywords locally (JUnit for Java, runner for Node.js) before deploying to a Step server
+- Using `automation-package.yaml` without setting the `version` field — this breaks forward compatibility when Step upgrades the schema
+
+## Response expectations
+
+- For keyword development questions, provide language-specific examples (Java, .NET, or JS/TS) based on what the user is working with
+- For YAML descriptor questions, show concrete `automation-package.yaml` snippets
+- For CLI questions, show the exact command with required flags
+- For architecture questions, help users decide between stateless vs stateful keywords, single vs modular keyword design, and YAML vs code-based entity declaration
+- When uncertain about version-specific behavior, point the user to the relevant live doc URL

--- a/step-dev/references/automation-packages.md
+++ b/step-dev/references/automation-packages.md
@@ -1,0 +1,514 @@
+# Automation Packages and YAML Descriptor
+
+> Live docs:
+> - Automation Packages overview: https://step.dev/knowledgebase/devops/automation-packages-overview/
+> - Automation Package Descriptor: https://step.dev/knowledgebase/devops/automation-package-yaml/
+> - Automation Package in Java: https://step.dev/knowledgebase/devops/automation-package-java/
+> - Automation Package Libraries: https://step.dev/knowledgebase/devops/automation-package-libraries/
+> - Multi-version support: https://step.dev/knowledgebase/devops/automation-package-multi-version/
+> - Getting started: https://step.dev/knowledgebase/devops/getting-started-with-automation-packages/
+
+## Table of contents
+
+1. [What is an Automation Package](#what-is-an-automation-package)
+2. [Supported entities](#supported-entities)
+3. [Package operations](#package-operations)
+4. [Package formats and layout](#package-formats-and-layout)
+5. [YAML descriptor](#yaml-descriptor)
+6. [Keywords in YAML](#keywords-in-yaml)
+7. [Plans in YAML](#plans-in-yaml)
+8. [Parameters](#parameters)
+9. [Schedules](#schedules)
+10. [Notification presets and alerting rules](#notification-presets-and-alerting-rules)
+11. [Fragment files](#fragment-files)
+12. [Java-specific declarations](#java-specific-declarations)
+13. [Package sources](#package-sources)
+14. [Automation Package Libraries](#automation-package-libraries)
+15. [IDE setup](#ide-setup)
+
+---
+
+## What is an Automation Package
+
+An Automation Package is a self-contained set of Plans and their related entities (Keywords, Parameters, Resources, Schedules, Alerting Rules) that can be executed on a Step controller or deployed to it for later use.
+
+The standard consists of:
+- **Automation Package syntax** — a declarative YAML format for describing automation workflows
+- **Automation Package format** — a standard for packaging entities (JAR, ZIP, Folder, DLL)
+- **Automation Package CLI** — tools to build, execute, and deploy packages
+
+---
+
+## Supported entities
+
+| Entity | Description |
+|---|---|
+| **Keywords** | Encapsulate automation logic — the building blocks of plans |
+| **Plans** | Define the operational logic Step performs |
+| **Parameters** | Key/value pairs for modular, environment-specific workflows |
+| **Schedules** | Define periodic plan executions (cron-based) |
+| **Resources** | Bundled data — Excel/CSV files, script files, etc. |
+| **Notification Presets** | Define how to send notifications (email, webhook) |
+| **Alerting Rules** | React to execution events with notifications or incident management |
+
+---
+
+## Package operations
+
+| Operation | Description |
+|---|---|
+| **Package** | Create an archive from the entities (bundling step) |
+| **Publish** | Upload to an artifact repository without further action |
+| **Deploy** | Upload to a Step server, make all entities available, activate schedules and alerting rules |
+| **Execute** | One-off execution in a temporary isolated context — content is not permanently deployed |
+
+---
+
+## Package formats and layout
+
+### JAR (Java)
+
+Standard JAR containing compiled Java classes, dependencies, and `automation-package.yaml` at the root. Built with Maven or any Java build tool.
+
+```
+META-INF/              # jar metadata
+step/                  # Java classes - keywords
+org/                   # Java classes - dependencies
+automation-package.yaml
+```
+
+### ZIP
+
+Standard ZIP archive with `automation-package.yaml` at the root plus any referenced resources.
+
+```
+automation-package.yaml
+Demo_JMeter.jmx        # JMeter test plan
+opencart-test.js        # K6 script
+```
+
+### Folder (exploded)
+
+Raw directory structure — supported only by the Step CLI.
+
+### DLL (.NET)
+
+Single DLL file with keywords declared via `[Keyword]` annotation. Additional dependencies can be bundled as a ZIP library. YAML descriptors are not yet supported for .NET packages.
+
+---
+
+## YAML descriptor
+
+The automation package is defined in `automation-package.yaml`. Top-level fields:
+
+```yaml
+---
+version: 1.0.0          # schema version — required for forward compatibility
+name: "my-package"       # unique identifier — updates existing package with same name on deploy
+keywords:                # optional
+plans:                   # optional
+parameters:              # optional
+schedules:               # optional
+notificationPresets:     # optional
+alertingRules:           # optional
+fragments:               # optional (include modular YAML files)
+```
+
+### Schema versions
+
+| Version | Description | Step compatibility |
+|---|---|---|
+| 1.2.0 | Password-protected data sources and Excel files | 29.x+ |
+| 1.1.1 | K6 directory support | 28.x+ |
+| 1.1.0 | Before & after sections in plans | 27.x |
+| 1.0.0 | Initial version | 24.x–26.x |
+
+Always set the `version` field explicitly to maintain forward compatibility.
+
+---
+
+## Keywords in YAML
+
+All Step keyword types are supported except Astra, QF Test, and PDF Test. Java keywords declared with `@Keyword` in code are automatically included and do not need YAML declarations.
+
+### JMeter
+
+```yaml
+keywords:
+  - JMeter:
+      name: "JMeter keyword from automation package"
+      description: "JMeter keyword 1"
+      jmeterTestplan: "jmeterProject1/jmeterProject1.xml"
+```
+
+### Cypress
+
+```yaml
+keywords:
+  - Cypress:
+      name: eCommerce - Typical visit
+      cypressProject: cypress-test/
+      spec: "opencart.cy.js"
+```
+
+### Grafana K6
+
+```yaml
+keywords:
+  - K6:
+      name: 'OpenCart home'
+      scriptFile: "opencart-test.js"
+      vus: 1
+      iterations: 1
+```
+
+- `scriptFile` — relative path to the K6 script
+- `scriptDirectory` (optional) — directory containing the script and local modules. All required modules must reside within this directory
+- `vus` (optional) — concurrent virtual users
+- `iterations` (optional) — total iterations across all VUs
+
+### .NET
+
+```yaml
+keywords:
+  - DotNet:
+      name: "Open_Chrome_and_search_in_Google"
+      dllFile: "DotNet/SeleniumKeywords.dll"
+      librariesFile: "DotNet/AllDlls.zip"
+```
+
+### Node.js (JavaScript / TypeScript)
+
+```yaml
+keywords:
+  - Node:
+      name: MyNodeKeyword
+      jsfile: nodejs-keywords/
+```
+
+The referenced project should contain `package.json` and keyword definitions in `keywords/`.
+
+### Composite keywords
+
+```yaml
+keywords:
+  - Composite:
+      name: "Composite Keyword"
+      plan:
+        root:
+          sequence:
+            children:
+              - echo:
+                  text: "In Composite keyword"
+              - return:
+                  output:
+                    - compositeOutput: "Composite Keyword output value"
+```
+
+---
+
+## Plans in YAML
+
+Plans are tree structures with a required `root` node defining the plan type. Common node properties:
+- `nodeName` (optional) — node name
+- `categories` (optional) — categories for filtering
+- `description` (optional) — description text
+- `children` (optional) — child nodes
+
+### Basic plan
+
+```yaml
+plans:
+  - name: "Simple plan"
+    categories:
+      - "FunctionalTests"
+    root:
+      testCase:
+        children:
+          - callKeyword:
+              keyword: "My Keyword"
+```
+
+### Keyword call with inputs and routing
+
+```yaml
+- callKeyword:
+    keyword: "My Keyword"
+    inputs:
+      - myInputNumber: 1
+      - myInputBoolean: true
+      - myInputString: "some input"
+    routing:
+      - agentOS: "windows"
+```
+
+### Thread group (load testing)
+
+With literal values:
+```yaml
+- threadGroup:
+    users: 5
+    iterations: 10
+    children:
+      - callKeyword:
+          keyword: "OpenCart home"
+```
+
+With dynamic expressions (Groovy):
+```yaml
+- threadGroup:
+    users:
+      expression: "nbUsers"
+    iterations:
+      expression: "nbIterations"
+```
+
+### Full load test example
+
+```yaml
+---
+version: 1.0.0
+name: "load-testing-k6-automation-package"
+keywords:
+  - K6:
+      name: 'OpenCart home'
+      vus: 1
+      iterations: 1
+      scriptFile: "opencart-test.js"
+plans:
+  - name: "Opencart load test plan"
+    root:
+      testScenario:
+        children:
+          - threadGroup:
+              users: 5
+              iterations: 10
+              children:
+                - callKeyword:
+                    keyword: "OpenCart home"
+```
+
+### Agent provisioning (Kubernetes)
+
+Auto-detect agents:
+```yaml
+plans:
+  - name: "My Plan"
+    agents: auto_detect
+```
+
+Manual specification:
+```yaml
+plans:
+  - name: "My Plan"
+    agents:
+      - pool: java-enterprise-agent
+        replicas: 2
+        image: docker-dev.exense.ch/test:agent-java-custom
+```
+
+### Plain text plans
+
+Include existing plain text plan files:
+```yaml
+plansPlainText:
+  - file: "plans/this-is-a-plain-text-plan.plan"
+    name: "this is a plain text plan"
+    rootType: TestCase
+    categories:
+      - myTestCategory
+```
+
+### Converting between formats
+
+- **Visual to YAML**: generate YAML from the visual plan editor in the Step UI (auto-excludes default values)
+- **YAML to visual**: paste YAML source when creating a plan in the UI
+
+---
+
+## Parameters
+
+Define environment-specific values with optional activation scripts (Groovy):
+
+```yaml
+parameters:
+  - key: "baseURL"
+    value: "http://test.com"
+    activationScript: "env == 'TEST'"
+  - key: "baseURL"
+    value: "http://prod.com"
+    activationScript: "env == 'PROD'"
+  - key: "fullURL"
+    value:
+      expression: baseURL + "/something"
+```
+
+---
+
+## Schedules
+
+Define periodic executions with cron expressions:
+
+```yaml
+schedules:
+  - name: "Opencart synthetic monitoring schedule"
+    cron: "0 0/1 * * * ?"
+    planName: "Opencart synthetic monitoring plan"
+```
+
+---
+
+## Notification presets and alerting rules
+
+### Notification presets
+
+```yaml
+notificationPresets:
+  - EmailNotification:
+      presetName: "Sample mail"
+      upstreamPreset: "Mail"
+      subject:
+        data: "${eventSummary}"
+        protection: READONLY
+  - WebhookNotification:
+      presetName: "Sample Webhook call"
+      upstreamPreset: "Webhook"
+      url:
+        data: "https://example.org"
+      method:
+        data: "POST"
+      body:
+        data: '{"Hello": "World"}'
+      headers:
+        data:
+          "X-Step-URL": "${controllerUrl}"
+```
+
+### Alerting rules
+
+```yaml
+alertingRules:
+  - description: "Send email for incident"
+    name: "Monitoring email alert"
+    eventClass: IncidentOpenedEvent
+    conditions:
+      - BindingCondition:
+          bindingKey: "executionParameters"
+          predicate:
+            BindingExistsPredicate: {}
+      - BindingCondition:
+          bindingKey: "executionParameters[env]"
+          predicate:
+            BindingValueEqualsPredicate:
+              value: "PROD"
+    actions:
+      - NotificationAction:
+          notification:
+            EmailNotification:
+              upstreamPreset: "Sample Mail"
+              from:
+                data: "me@example.org"
+              to:
+                data:
+                  - "you@example.org"
+```
+
+Note: `BindingExistsPredicate: {}` requires explicit empty braces — omitting them produces invalid YAML.
+
+---
+
+## Fragment files
+
+Fragment files enable modular automation packages. Each fragment declares entities using the same syntax and is included via the `fragments` field:
+
+```yaml
+version: 1.0.0
+name: "My Automation Package"
+fragments:
+  - "fragment1.yml"
+  - "fragment2.yml"
+  - "fragments/*.yaml"    # wildcard — fragments must be in a subdirectory
+```
+
+Each fragment contains only the entity declarations (no top-level `name` or `version`):
+
+```yaml
+# plan1.yml
+plans:
+  - name: "Plan 1"
+    root:
+      testCase:
+        children:
+          - echo:
+              text: "Hello world 1"
+```
+
+Limitation: fragments at the root of the automation package cannot be referenced by wildcards.
+
+---
+
+## Java-specific declarations
+
+In addition to the YAML descriptor, Java packages support declaring entities directly in code.
+
+### Keywords in Java
+
+Any class extending `AbstractKeyword` with `@Keyword`-annotated methods is automatically included — no YAML entry needed.
+
+### Plans via annotation
+
+For single-keyword plans, annotate the keyword method with `@Plan`:
+
+```java
+@Plan()
+@Keyword
+public void myPlanMadeOfOneKeyword() {
+    output.add("hello", "world");
+}
+```
+
+### Plan categories
+
+```java
+@Plan()
+@PlanCategories({"PerformanceTest", "Playwright"})
+@Keyword
+public void myPlanMadeOfOneKeyword() {
+    output.add("hello", "world");
+}
+```
+
+### Inline plans (deprecated)
+
+Plain text plans defined via annotation. Declaring plans in YAML is now the recommended approach.
+
+---
+
+## Package sources
+
+Automation Packages can be provided from three sources:
+
+1. **Direct file upload** — via Step UI or CLI. Simplest approach for local builds.
+2. **Maven artifact coordinates** — reference artifacts in any Maven-compatible repository (Artifactory, Nexus, GitHub Packages, CodeArtifact). Step creates one resource per unique coordinate per tenant. SNAPSHOT artifacts are not auto-refreshed — use explicit refresh.
+3. **Existing Step resource** (libraries only) — reuse a library already deployed to Step.
+
+---
+
+## Automation Package Libraries
+
+AP Libraries are reusable, versioned code artifacts that provide shared logic across multiple Automation Packages — common utilities, shared keywords, shared plans. They are deployed and referenced independently from individual packages.
+
+Libraries can be provided as files, Maven coordinates, or managed libraries (referenced by name on the Step server).
+
+---
+
+## IDE setup
+
+Download the JSON schema from your Step instance:
+```
+https://<your-step-instance>/rest/automation-packages/schema
+```
+
+**IntelliJ IDEA**: Settings > Languages & Frameworks > JSON Schema Mappings. Add the schema and associate it with your `automation-package.yaml` files for auto-completion and validation.
+
+**Visual Studio**: similar JSON schema association in settings.

--- a/step-dev/references/automation-packages.md
+++ b/step-dev/references/automation-packages.md
@@ -1,6 +1,7 @@
 # Automation Packages and YAML Descriptor
 
 > Live docs:
+>
 > - Automation Packages overview: https://step.dev/knowledgebase/devops/automation-packages-overview/
 > - Automation Package Descriptor: https://step.dev/knowledgebase/devops/automation-package-yaml/
 > - Automation Package in Java: https://step.dev/knowledgebase/devops/automation-package-java/
@@ -32,6 +33,7 @@
 An Automation Package is a self-contained set of Plans and their related entities (Keywords, Parameters, Resources, Schedules, Alerting Rules) that can be executed on a Step controller or deployed to it for later use.
 
 The standard consists of:
+
 - **Automation Package syntax** — a declarative YAML format for describing automation workflows
 - **Automation Package format** — a standard for packaging entities (JAR, ZIP, Folder, DLL)
 - **Automation Package CLI** — tools to build, execute, and deploy packages
@@ -41,7 +43,7 @@ The standard consists of:
 ## Supported entities
 
 | Entity | Description |
-|---|---|
+| --- | --- |
 | **Keywords** | Encapsulate automation logic — the building blocks of plans |
 | **Plans** | Define the operational logic Step performs |
 | **Parameters** | Key/value pairs for modular, environment-specific workflows |
@@ -55,7 +57,7 @@ The standard consists of:
 ## Package operations
 
 | Operation | Description |
-|---|---|
+| --- | --- |
 | **Package** | Create an archive from the entities (bundling step) |
 | **Publish** | Upload to an artifact repository without further action |
 | **Deploy** | Upload to a Step server, make all entities available, activate schedules and alerting rules |
@@ -69,7 +71,7 @@ The standard consists of:
 
 Standard JAR containing compiled Java classes, dependencies, and `automation-package.yaml` at the root. Built with Maven or any Java build tool.
 
-```
+```text
 META-INF/              # jar metadata
 step/                  # Java classes - keywords
 org/                   # Java classes - dependencies
@@ -80,7 +82,7 @@ automation-package.yaml
 
 Standard ZIP archive with `automation-package.yaml` at the root plus any referenced resources.
 
-```
+```text
 automation-package.yaml
 Demo_JMeter.jmx        # JMeter test plan
 opencart-test.js        # K6 script
@@ -116,7 +118,7 @@ fragments:               # optional (include modular YAML files)
 ### Schema versions
 
 | Version | Description | Step compatibility |
-|---|---|---|
+| --- | --- | --- |
 | 1.2.0 | Password-protected data sources and Excel files | 29.x+ |
 | 1.1.1 | K6 directory support | 28.x+ |
 | 1.1.0 | Before & after sections in plans | 27.x |
@@ -209,6 +211,7 @@ keywords:
 ## Plans in YAML
 
 Plans are tree structures with a required `root` node defining the plan type. Common node properties:
+
 - `nodeName` (optional) — node name
 - `categories` (optional) — categories for filtering
 - `description` (optional) — description text
@@ -244,6 +247,7 @@ plans:
 ### Thread group (load testing)
 
 With literal values:
+
 ```yaml
 - threadGroup:
     users: 5
@@ -254,6 +258,7 @@ With literal values:
 ```
 
 With dynamic expressions (Groovy):
+
 ```yaml
 - threadGroup:
     users:
@@ -290,6 +295,7 @@ plans:
 ### Agent provisioning (Kubernetes)
 
 Auto-detect agents:
+
 ```yaml
 plans:
   - name: "My Plan"
@@ -297,6 +303,7 @@ plans:
 ```
 
 Manual specification:
+
 ```yaml
 plans:
   - name: "My Plan"
@@ -309,6 +316,7 @@ plans:
 ### Plain text plans
 
 Include existing plain text plan files:
+
 ```yaml
 plansPlainText:
   - file: "plans/this-is-a-plain-text-plan.plan"
@@ -504,7 +512,8 @@ Libraries can be provided as files, Maven coordinates, or managed libraries (ref
 ## IDE setup
 
 Download the JSON schema from your Step instance:
-```
+
+```text
 https://<your-step-instance>/rest/automation-packages/schema
 ```
 

--- a/step-dev/references/automation-packages.md
+++ b/step-dev/references/automation-packages.md
@@ -6,7 +6,6 @@
 > - Automation Package in Java: https://step.dev/knowledgebase/devops/automation-package-java/
 > - Automation Package Libraries: https://step.dev/knowledgebase/devops/automation-package-libraries/
 > - Multi-version support: https://step.dev/knowledgebase/devops/automation-package-multi-version/
-> - Getting started: https://step.dev/knowledgebase/devops/getting-started-with-automation-packages/
 
 ## Table of contents
 

--- a/step-dev/references/cli-and-deployment.md
+++ b/step-dev/references/cli-and-deployment.md
@@ -1,6 +1,7 @@
 # Step CLI, Maven Plugin, and Deployment
 
 > Live docs:
+>
 > - Step CLI: https://step.dev/knowledgebase/devops/automation-package-cli/step-cli/
 > - Maven plugin: https://step.dev/knowledgebase/devops/automation-package-cli/ap-maven-plugin/
 > - Automation as Code (CI/CD context): https://step.dev/knowledgebase/devops/automation-as-code/
@@ -29,6 +30,7 @@
 ## Step CLI overview
 
 The Step CLI handles all Automation Package operations:
+
 - Execute packages locally or remotely on a Step server
 - Deploy packages to a Step server (full installation with schedule activation)
 - Deploy libraries independently
@@ -42,6 +44,7 @@ The Step CLI handles all Automation Package operations:
 - **Step Enterprise**: download from the Enterprise download section
 
 Requirements:
+
 - Use the same CLI version as your Step server
 - Java JRE 11+ must be installed
 
@@ -74,7 +77,7 @@ step ap execute --local
 
 Add a `.apignore` file to the package root to exclude files during packaging. Same syntax as `.gitignore`.
 
-```
+```text
 /ignored-folder
 /ignoredFile.yml
 ```
@@ -95,6 +98,7 @@ step ap execute --local -p /path/to/package/
 ### Limitations
 
 Local execution does not support:
+
 - Node.js keywords
 - .NET keywords
 - SoapUI keywords
@@ -173,6 +177,7 @@ step ap deploy \
 ### Deploy with libraries
 
 Same syntax as execute:
+
 ```bash
 step ap deploy -p ./package.jar -l ./library.jar
 step ap deploy -p ./package.jar -l mvn:group:artifact:version
@@ -182,6 +187,7 @@ step ap deploy -p ./package.jar -l managed:MyCommonJavaLib
 ### Force refresh of SNAPSHOT artifacts
 
 When other packages in the same tenant use the same SNAPSHOT coordinate:
+
 ```bash
 step ap deploy -p ./package-SNAPSHOT.jar -l mvn:group:artifact:version-SNAPSHOT --forceRefreshOfSnapshots
 ```
@@ -220,12 +226,14 @@ The activation expression (Groovy) determines which version is selected at runti
 Select which plans to execute:
 
 ### By name
+
 ```bash
 step ap execute --includePlans=PlanA,PlanB
 step ap execute --excludePlans=SkipThisPlan
 ```
 
 ### By category
+
 ```bash
 step ap execute --includeCategories=FunctionalTest,Playwright
 step ap execute --excludeCategories=PerformanceTest
@@ -266,6 +274,7 @@ All CLI options can be defined in configuration files.
 ### Example
 
 `~/stepcli.properties`:
+
 ```properties
 stepUrl=https://my-step-server.example.com
 token=<API_KEY>
@@ -273,6 +282,7 @@ projectName=Common
 ```
 
 `jmeter_cli.properties` (project-specific):
+
 ```properties
 projectName=JMeter_Tests
 ```
@@ -285,11 +295,13 @@ step ap execute -c jmeter_cli.properties
 ### Execution parameters
 
 Use the `|` delimiter for multiple parameters in config files:
+
 ```properties
 executionParameters=myParam1=myValue1|myParam2=myValue2
 ```
 
 On the command line, use `-ep` for each parameter:
+
 ```bash
 step ap execute -ep myParam1=myValue1 -ep myParam2=myValue2
 ```
@@ -369,6 +381,7 @@ public class RunAutomationPackageTest {}
 Three approaches:
 
 **1. Annotation:**
+
 ```java
 @RunWith(Step.class)
 @ExecutionParameters({"MyParam1", "Value of param 1", "MyParam2", "Value of param 2"})

--- a/step-dev/references/cli-and-deployment.md
+++ b/step-dev/references/cli-and-deployment.md
@@ -5,7 +5,6 @@
 > - Maven plugin: https://step.dev/knowledgebase/devops/automation-package-cli/ap-maven-plugin/
 > - Automation as Code (CI/CD context): https://step.dev/knowledgebase/devops/automation-as-code/
 > - Automation Package in Java (JUnit): https://step.dev/knowledgebase/devops/automation-package-java/
-> - Getting started: https://step.dev/knowledgebase/devops/getting-started-with-automation-packages/
 
 ## Table of contents
 

--- a/step-dev/references/cli-and-deployment.md
+++ b/step-dev/references/cli-and-deployment.md
@@ -1,0 +1,420 @@
+# Step CLI, Maven Plugin, and Deployment
+
+> Live docs:
+> - Step CLI: https://step.dev/knowledgebase/devops/automation-package-cli/step-cli/
+> - Maven plugin: https://step.dev/knowledgebase/devops/automation-package-cli/ap-maven-plugin/
+> - Automation as Code (CI/CD context): https://step.dev/knowledgebase/devops/automation-as-code/
+> - Automation Package in Java (JUnit): https://step.dev/knowledgebase/devops/automation-package-java/
+> - Getting started: https://step.dev/knowledgebase/devops/getting-started-with-automation-packages/
+
+## Table of contents
+
+1. [Step CLI overview](#step-cli-overview)
+2. [Getting the CLI](#getting-the-cli)
+3. [CLI usage and help](#cli-usage-and-help)
+4. [Automation Package location](#automation-package-location)
+5. [Local execution](#local-execution)
+6. [Remote execution](#remote-execution)
+7. [Deploying packages](#deploying-packages)
+8. [Deploying libraries](#deploying-libraries)
+9. [Multi-version deployment](#multi-version-deployment)
+10. [Filtering plans](#filtering-plans)
+11. [Execution reports](#execution-reports)
+12. [CLI configuration files](#cli-configuration-files)
+13. [Maven plugin](#maven-plugin)
+14. [Local execution with JUnit](#local-execution-with-junit)
+15. [CI/CD integration](#cicd-integration)
+
+---
+
+## Step CLI overview
+
+The Step CLI handles all Automation Package operations:
+- Execute packages locally or remotely on a Step server
+- Deploy packages to a Step server (full installation with schedule activation)
+- Deploy libraries independently
+- Works with folders, ZIPs, JARs, and Maven artifact coordinates
+
+---
+
+## Getting the CLI
+
+- **Step Open Source**: download from the [GitHub release page](https://github.com/exense/step/releases)
+- **Step Enterprise**: download from the Enterprise download section
+
+Requirements:
+- Use the same CLI version as your Step server
+- Java JRE 11+ must be installed
+
+---
+
+## CLI usage and help
+
+```bash
+step                        # top-level help
+step ap --help              # automation package operations
+step ap execute --help      # detailed help for execute
+step ap deploy --help       # detailed help for deploy
+```
+
+---
+
+## Automation Package location
+
+The CLI works with folders, ZIPs, or JARs. Without the `-p` option, it treats the current directory as the package root.
+
+```bash
+# Explicit path
+step ap execute --local -p /path/to/automation-package/
+
+# Current directory (must contain automation-package.yaml)
+step ap execute --local
+```
+
+### Excluding files with .apignore
+
+Add a `.apignore` file to the package root to exclude files during packaging. Same syntax as `.gitignore`.
+
+```
+/ignored-folder
+/ignoredFile.yml
+```
+
+Only supported for folder-based packages deployed or executed via the Step CLI (not Maven JAR packaging).
+
+---
+
+## Local execution
+
+Execute all plans locally without a Step server:
+
+```bash
+step ap execute --local
+step ap execute --local -p /path/to/package/
+```
+
+### Limitations
+
+Local execution does not support:
+- Node.js keywords
+- .NET keywords
+- SoapUI keywords
+- Silk Performer keywords
+- Java keywords requiring package libraries
+
+---
+
+## Remote execution
+
+Execute packages on a Step server in isolation (one-off, temporary context):
+
+```bash
+step ap execute \
+  --stepUrl=http://localhost:8080 \
+  --token=<API_KEY> \
+  --projectName=JMeter_Tests
+```
+
+Remote executions are ephemeral — the package exists only during execution and is not permanently deployed.
+
+### Execute from artifact repository
+
+```bash
+step ap execute \
+  --stepUrl=http://localhost:8080 \
+  -p "mvn:groupId:artefactId:version[:classifier:type]"
+```
+
+Classifier and type are optional. For type without classifier: `mvn:groupId:artefactId:version::type`
+
+### Execute with libraries
+
+```bash
+# Library as file
+step ap execute -p ./package.jar -l ./library.jar
+
+# Library from Maven
+step ap execute -p ./package.jar -l mvn:ch.exense.step.testing.libraries:java-keyword-library:1.0.0
+
+# Managed library (deployed on Step server)
+step ap execute -p ./package.jar -l managed:MyCommonJavaLib -c cli.properties
+```
+
+### Wrap plans into a TestSet
+
+By default, each plan runs as a separate execution. Use `--wrapIntoTestSet` to run all plans in a single TestSet:
+
+```bash
+step ap execute --stepUrl=http://localhost:8080 --wrapIntoTestSet
+# Optionally control parallelism:
+step ap execute --stepUrl=http://localhost:8080 --wrapIntoTestSet --numberOfThreads=4
+```
+
+---
+
+## Deploying packages
+
+Deploy makes all entities available on the Step server and activates schedules and alerting rules:
+
+```bash
+step ap deploy \
+  --stepUrl=http://localhost:8080 \
+  --token=<API_KEY> \
+  --projectName=Common
+```
+
+### Deploy from artifact repository
+
+```bash
+step ap deploy \
+  --stepUrl=http://localhost:8080 \
+  -p "mvn:groupId:artefactId:version"
+```
+
+### Deploy with libraries
+
+Same syntax as execute:
+```bash
+step ap deploy -p ./package.jar -l ./library.jar
+step ap deploy -p ./package.jar -l mvn:group:artifact:version
+step ap deploy -p ./package.jar -l managed:MyCommonJavaLib
+```
+
+### Force refresh of SNAPSHOT artifacts
+
+When other packages in the same tenant use the same SNAPSHOT coordinate:
+```bash
+step ap deploy -p ./package-SNAPSHOT.jar -l mvn:group:artifact:version-SNAPSHOT --forceRefreshOfSnapshots
+```
+
+---
+
+## Deploying libraries
+
+Deploy libraries independently (useful for shared libraries across multiple packages and projects):
+
+```bash
+# Deploy a library
+step library deploy -l mvn:ch.exense.step.testing.libraries:java-keyword-library:1.0.0
+
+# Deploy as managed library (referenceable by name)
+step library deploy -l mvn:ch.exense.step.testing.libraries:java-keyword-library:1.0.0 --managed="MyCommonJavaLib"
+```
+
+---
+
+## Multi-version deployment
+
+Deploy multiple versions of the same package for different environments:
+
+```bash
+step ap deploy --versionName="PROD" --activationExpression="env == \"PROD\""
+step ap deploy --versionName="TEST" --activationExpression="env == \"TEST\""
+```
+
+The activation expression (Groovy) determines which version is selected at runtime.
+
+---
+
+## Filtering plans
+
+Select which plans to execute:
+
+### By name
+```bash
+step ap execute --includePlans=PlanA,PlanB
+step ap execute --excludePlans=SkipThisPlan
+```
+
+### By category
+```bash
+step ap execute --includeCategories=FunctionalTest,Playwright
+step ap execute --excludeCategories=PerformanceTest
+```
+
+These options can be combined.
+
+---
+
+## Execution reports
+
+```bash
+# JUnit XML report (written to file by default)
+step ap execute --reportType=junit
+
+# Aggregated report (printed to stdout by default)
+step ap execute --reportType=aggregated
+
+# Custom output destination
+step ap execute --reportType="junit;output=file,stdout"
+
+# Custom report directory
+step ap execute --reportType=junit --reportDir=./reports
+```
+
+---
+
+## CLI configuration files
+
+All CLI options can be defined in configuration files.
+
+### Resolution order (last wins)
+
+1. `~/stepcli.properties` (home folder — auto-loaded if present)
+2. Configuration files passed with `-c` (left to right)
+3. Command-line arguments
+
+### Example
+
+`~/stepcli.properties`:
+```properties
+stepUrl=https://my-step-server.example.com
+token=<API_KEY>
+projectName=Common
+```
+
+`jmeter_cli.properties` (project-specific):
+```properties
+projectName=JMeter_Tests
+```
+
+```bash
+step ap execute -c jmeter_cli.properties
+# Uses stepUrl and token from home config, projectName from jmeter_cli.properties
+```
+
+### Execution parameters
+
+Use the `|` delimiter for multiple parameters in config files:
+```properties
+executionParameters=myParam1=myValue1|myParam2=myValue2
+```
+
+On the command line, use `-ep` for each parameter:
+```bash
+step ap execute -ep myParam1=myValue1 -ep myParam2=myValue2
+```
+
+Parameters from all sources are merged. When a key is defined multiple times, the same resolution order applies (last wins).
+
+---
+
+## Maven plugin
+
+For Java projects, the Maven plugin provides the same operations as the CLI.
+
+### Execute remotely
+
+```bash
+mvn package step:execute-automation-package \
+  "-Dstep.url=https://your.step.server/" \
+  "-Dstep.step-project-name=Common" \
+  "-Dstep.auth-token=your_token"
+```
+
+### Deploy
+
+```bash
+mvn package step:deploy-automation-package \
+  "-Dstep.url=https://your.step.server/" \
+  "-Dstep.step-project-name=Common" \
+  "-Dstep.auth-token=your_token"
+```
+
+See the [Maven plugin documentation](https://step.dev/knowledgebase/devops/automation-package-cli/ap-maven-plugin/) for full plugin configuration and goals.
+
+---
+
+## Local execution with JUnit
+
+For Java packages, use JUnit to execute packages locally without a Step server.
+
+### JUnit 4
+
+```java
+import org.junit.runner.RunWith;
+import step.junit.runner.Step;
+
+@RunWith(Step.class)
+public class RunAutomationPackageTest {}
+```
+
+### JUnit 5
+
+```java
+import step.junit5.runner.StepJUnit5;
+
+public class RunAutomationPackageTest extends StepJUnit5 {}
+```
+
+### Running
+
+```bash
+mvn test -Dtest="RunAutomationPackageTest"
+```
+
+The Step runner executes all plans in the Automation Package.
+
+### Filtering plans in JUnit
+
+```java
+@RunWith(Step.class)
+@IncludePlanCategories({"Playwright", "JMeter", "FunctionalTest"})
+@ExcludePlanCategories({"PerformanceTest"})
+@ExcludePlans({"My Plan name to be excluded"})
+public class RunAutomationPackageTest {}
+```
+
+### Execution parameters for local execution
+
+Three approaches:
+
+**1. Annotation:**
+```java
+@RunWith(Step.class)
+@ExecutionParameters({"MyParam1", "Value of param 1", "MyParam2", "Value of param 2"})
+public class RunAutomationPackageTest {}
+```
+
+**2. Environment variables:** any `STEP_*` variable maps to the parameter name without the prefix (e.g., `STEP_MyParam` becomes `MyParam`)
+
+**3. System properties:** same mapping as environment variables (`-DSTEP_MyParam=value`)
+
+### Required dependencies
+
+```xml
+<!-- Step OS, JUnit 4 -->
+<dependency>
+    <groupId>ch.exense.step</groupId>
+    <artifactId>step-automation-packages-junit</artifactId>
+    <version>${step.version}</version>
+    <scope>provided</scope> <!-- use test scope for local-only -->
+</dependency>
+
+<!-- Step OS, JUnit 5 -->
+<dependency>
+    <groupId>ch.exense.step</groupId>
+    <artifactId>step-automation-packages-junit5</artifactId>
+    <version>${step.version}</version>
+    <scope>provided</scope>
+</dependency>
+
+<!-- Step Enterprise equivalents use groupId: ch.exense.step-enterprise -->
+<!-- and artifactId: step-automation-packages-junit-ee / step-automation-packages-junit5-ee -->
+```
+
+---
+
+## CI/CD integration
+
+The typical CI/CD integration pattern:
+
+1. **Store automation code** alongside application code in the same repository
+2. **Build the package** in the CI/CD pipeline together with the application
+3. **Publish** to an artifact repository (optional, for multi-server deployments)
+4. **Execute or deploy** at different pipeline stages:
+   - **Test phase**: execute plans after deploying the app to test environment (load tests, E2E tests, smoke tests)
+   - **Operate phase**: deploy for self-service RPA tasks and recurring automation
+   - **Monitor phase**: deploy for synthetic monitoring with scheduled plan execution
+
+The Step CLI and Maven plugin integrate naturally with any CI/CD tool (Jenkins, GitLab CI, GitHub Actions, etc.) since they are standard command-line operations.

--- a/step-dev/references/keywords.md
+++ b/step-dev/references/keywords.md
@@ -6,7 +6,7 @@
 > - Tutorials: https://step.dev/tutorials/basic-keyword-development/
 > - Java samples: https://github.com/exense/step-samples/tree/master/keywords/java
 > - JS samples: https://github.com/exense/step-node/tree/master/examples
-> - .NET samples: https://github.com/exense/step-samples/tree/master/keywords/dotnet50
+> - .NET samples: https://github.com/exense/step-samples/tree/master/keywords/dotnet80
 
 ## Table of contents
 

--- a/step-dev/references/keywords.md
+++ b/step-dev/references/keywords.md
@@ -1,6 +1,7 @@
 # Keywords — Development and API
 
 > Live docs:
+>
 > - Keyword Development: https://step.dev/knowledgebase/devdocs/keyword-development/
 > - Keyword API: https://step.dev/knowledgebase/devdocs/keywordapi/
 > - Tutorials: https://step.dev/tutorials/basic-keyword-development/
@@ -29,6 +30,7 @@
 A custom keyword is a user-defined block of automation logic implemented in code. Unlike plugin-based keywords (Cypress, JMeter, K6, etc.), custom keywords let you integrate any tool, framework, or library into Step workflows.
 
 The Keyword API provides the interface to:
+
 - Define and configure keywords using annotations and class extensions
 - Access keyword inputs, session objects, and report data
 - Implement hooks for pre/post execution and error management
@@ -51,6 +53,7 @@ public class MyKeywords extends AbstractKeyword {
 ```
 
 The `@Keyword` annotation supports these attributes:
+
 - `name` — custom keyword name (defaults to method name)
 - `schema` — JSON schema for inputs
 - `description` — description shown in Step UI
@@ -83,12 +86,14 @@ exports.MyKeyword = async (input, output, session, properties) => {
 ```
 
 Each keyword receives four arguments:
+
 - **input** — input parameters from the Step plan, as a plain object
 - **output** — an `OutputBuilder` for return values, errors, and attachments
 - **session** — a Map scoped to the token's lifetime for sharing state between keyword calls
 - **properties** — flat key/value map of agent and token properties configured in Step
 
 Three optional module-level hooks can be exported alongside keywords:
+
 - `beforeKeyword(functionName)` — called before each keyword execution
 - `afterKeyword(functionName)` — called after each keyword execution, even on failure
 - `onError(exception, input, output, session, properties)` — called on error; return `true` to propagate, `false` to suppress
@@ -102,12 +107,14 @@ Keyword inputs are passed as a JSON object with open types. The developer choose
 ### Reading inputs in code
 
 **Java** (via inherited `input` object):
+
 ```java
 String homeUrl = input.getString("url");
 int elementIndex = input.getInt("index", 1);
 ```
 
 **Java** (via method arguments with `@Input` annotation — recommended):
+
 ```java
 @Keyword
 public void myKeyword(
@@ -122,11 +129,13 @@ public void myKeyword(
 Supported `@Input` types: `String`, `Integer`/`int`, `Long`/`long`, `Double`/`double`, `BigDecimal`, `BigInteger`, arrays/collections of supported types, Maps of strings to supported types, and POJOs with accessible fields.
 
 **.NET**:
+
 ```csharp
 string homeUrl = (string)input["url"];
 ```
 
 **JavaScript**:
+
 ```javascript
 var homeUrl = input['url'];
 ```
@@ -134,12 +143,14 @@ var homeUrl = input['url'];
 ### Passing inputs from code (for testing)
 
 **Java** (with `KeywordRunner`):
+
 ```java
 ExecutionContext ctx = KeywordRunner.getExecutionContext(properties, this.getClass());
 Output<JsonObject> output = ctx.run("MyKeyword", "{\"url\":\"http://www.example.com\", \"index\": 3}");
 ```
 
 **JavaScript** (with `runner`):
+
 ```javascript
 const runner = require('step-node-agent/api/runner/runner')({
     myProperty: 'value'  // equivalent to agent properties
@@ -214,6 +225,7 @@ The execution flow of a keyword:
 ### Implementing hooks
 
 **Java**:
+
 ```java
 @Override
 public void beforeKeyword(String keywordName, Keyword annotation) {
@@ -233,6 +245,7 @@ public boolean onError(Exception e) {
 ```
 
 **JavaScript** (module-level exports):
+
 ```javascript
 exports.beforeKeyword = async (functionName) => {
     console.log('Before:', functionName)
@@ -253,7 +266,7 @@ exports.onError = async (exception, input, output, session, properties) => {
 ## Stateless vs stateful keywords
 
 | Feature | Stateless | Stateful |
-|---|---|---|
+| --- | --- | --- |
 | Instance lifecycle | New instance per execution | Data shared via session |
 | Data persistence | None between executions | Persists in session across workflow |
 | Use case | Idempotent, isolated operations | Workflows needing shared state |
@@ -265,6 +278,7 @@ Use the session when keywords within a workflow need to share state — for exam
 The session is only available when keyword calls are grouped using the `Session` control in a plan. Objects stored in the session must implement `Closeable` or `AutoCloseable` to be cleaned up when the session is released.
 
 **Java**:
+
 ```java
 // Store in session
 session.put("browser", browser);
@@ -274,6 +288,7 @@ WebDriver browser = (WebDriver) session.get("browser");
 ```
 
 **JavaScript**:
+
 ```javascript
 // Store in session
 session.set('browser', browser)
@@ -292,6 +307,7 @@ const browser = session.get('browser')
 - **Technical errors** — unexpected exceptions (null pointer, connection timeout). Any uncaught exception is reported as a technical error. Catch and categorize them explicitly when possible.
 
 **Java**:
+
 ```java
 try {
     // automation logic
@@ -305,6 +321,7 @@ try {
 ```
 
 **JavaScript**:
+
 ```javascript
 try {
     // automation logic
@@ -322,6 +339,7 @@ Measurements track execution timing for analytics. A default measurement is crea
 Measurements work in a stack — `stopMeasure()` closes the most recently opened one.
 
 **Java**:
+
 ```java
 output.startMeasure("NavigateToPage");
 // do navigation
@@ -335,6 +353,7 @@ output.stopMeasure(data);  // stops NavigateToPage with analytics data
 ```
 
 **JavaScript**:
+
 ```javascript
 output.startMeasure('Navigate')
 // do something
@@ -362,6 +381,7 @@ Starting with Keyword API version 1.5.0 (Step 29), you can assign an explicit st
 The Keyword Proxy lets a parent keyword invoke child keywords directly from code, creating workflows without using Step plans. Java only.
 
 Key features:
+
 - Automatically shares the parent keyword's context (session, properties)
 - Manages output propagation (merge all outputs or set manually)
 - Creates measurements for all individual keyword calls
@@ -415,6 +435,7 @@ See the Keyword API javadoc for streaming file upload and advanced features.
 ### Resource management
 
 Clean up all resources explicitly — browsers, WebDriver instances, database connections, file handles, downloaded files. Approaches:
+
 1. Try/finally in the keyword function itself (simplest)
 2. `afterKeyword` hook (always runs, even on failure)
 3. Store resources in session with `Closeable`/`AutoCloseable` — cleaned up when session closes

--- a/step-dev/references/keywords.md
+++ b/step-dev/references/keywords.md
@@ -1,0 +1,437 @@
+# Keywords — Development and API
+
+> Live docs:
+> - Keyword Development: https://step.dev/knowledgebase/devdocs/keyword-development/
+> - Keyword API: https://step.dev/knowledgebase/devdocs/keywordapi/
+> - Tutorials: https://step.dev/tutorials/basic-keyword-development/
+> - Java samples: https://github.com/exense/step-samples/tree/master/keywords/java
+> - JS samples: https://github.com/exense/step-node/tree/master/examples
+> - .NET samples: https://github.com/exense/step-samples/tree/master/keywords/dotnet50
+
+## Table of contents
+
+1. [What is a custom keyword](#what-is-a-custom-keyword)
+2. [Keyword declaration by language](#keyword-declaration-by-language)
+3. [Keyword inputs](#keyword-inputs)
+4. [Keyword outputs](#keyword-outputs)
+5. [Keyword lifecycle and hooks](#keyword-lifecycle-and-hooks)
+6. [Stateless vs stateful keywords](#stateless-vs-stateful-keywords)
+7. [Error handling](#error-handling)
+8. [Measurements](#measurements)
+9. [Keyword Proxy (plans as code)](#keyword-proxy-plans-as-code)
+10. [Live reporting](#live-reporting)
+11. [Best practices](#best-practices)
+
+---
+
+## What is a custom keyword
+
+A custom keyword is a user-defined block of automation logic implemented in code. Unlike plugin-based keywords (Cypress, JMeter, K6, etc.), custom keywords let you integrate any tool, framework, or library into Step workflows.
+
+The Keyword API provides the interface to:
+- Define and configure keywords using annotations and class extensions
+- Access keyword inputs, session objects, and report data
+- Implement hooks for pre/post execution and error management
+
+---
+
+## Keyword declaration by language
+
+### Java
+
+Extend `AbstractKeyword` and annotate keyword methods with `@Keyword`:
+
+```java
+public class MyKeywords extends AbstractKeyword {
+    @Keyword
+    public void myKeyword() {
+        // automation logic
+    }
+}
+```
+
+The `@Keyword` annotation supports these attributes:
+- `name` — custom keyword name (defaults to method name)
+- `schema` — JSON schema for inputs
+- `description` — description shown in Step UI
+- `properties` — additional configuration properties
+
+### .NET
+
+Extend `AbstractScript` and annotate with `[Keyword]`:
+
+```csharp
+namespace STEP {
+    public class Keywords : StepApi.AbstractScript {
+        [Keyword(name = "My Keyword")]
+        public void MyKeyword() {
+            // your implementation
+        }
+    }
+}
+```
+
+### JavaScript / TypeScript (Node.js)
+
+Export async functions from CommonJS `.js` files in the `keywords/` directory (configurable via `step.keywords` in `package.json`). The export name becomes the keyword name in Step.
+
+```javascript
+exports.MyKeyword = async (input, output, session, properties) => {
+    const result = await doSomething(input['param'])
+    output.add('result', result)
+}
+```
+
+Each keyword receives four arguments:
+- **input** — input parameters from the Step plan, as a plain object
+- **output** — an `OutputBuilder` for return values, errors, and attachments
+- **session** — a Map scoped to the token's lifetime for sharing state between keyword calls
+- **properties** — flat key/value map of agent and token properties configured in Step
+
+Three optional module-level hooks can be exported alongside keywords:
+- `beforeKeyword(functionName)` — called before each keyword execution
+- `afterKeyword(functionName)` — called after each keyword execution, even on failure
+- `onError(exception, input, output, session, properties)` — called on error; return `true` to propagate, `false` to suppress
+
+---
+
+## Keyword inputs
+
+Keyword inputs are passed as a JSON object with open types. The developer chooses argument types but must read them accordingly.
+
+### Reading inputs in code
+
+**Java** (via inherited `input` object):
+```java
+String homeUrl = input.getString("url");
+int elementIndex = input.getInt("index", 1);
+```
+
+**Java** (via method arguments with `@Input` annotation — recommended):
+```java
+@Keyword
+public void myKeyword(
+    @Input(name = "myRequiredInput", required = true) int myRequiredInput,
+    @Input(name = "myOptionalInput", defaultValue = "3") int myOptionalInput,
+    @Input(name = "myString", defaultValue = "hello") String myString
+) {
+    // inputs are directly available as method parameters
+}
+```
+
+Supported `@Input` types: `String`, `Integer`/`int`, `Long`/`long`, `Double`/`double`, `BigDecimal`, `BigInteger`, arrays/collections of supported types, Maps of strings to supported types, and POJOs with accessible fields.
+
+**.NET**:
+```csharp
+string homeUrl = (string)input["url"];
+```
+
+**JavaScript**:
+```javascript
+var homeUrl = input['url'];
+```
+
+### Passing inputs from code (for testing)
+
+**Java** (with `KeywordRunner`):
+```java
+ExecutionContext ctx = KeywordRunner.getExecutionContext(properties, this.getClass());
+Output<JsonObject> output = ctx.run("MyKeyword", "{\"url\":\"http://www.example.com\", \"index\": 3}");
+```
+
+**JavaScript** (with `runner`):
+```javascript
+const runner = require('step-node-agent/api/runner/runner')({
+    myProperty: 'value'  // equivalent to agent properties
+})
+try {
+    const output = await runner.run('MyKeyword', { param: 'value' })
+    console.log(output.payload)
+} finally {
+    runner.close()  // releases the session
+}
+```
+
+---
+
+## Keyword outputs
+
+Use the inherited `output` object (an `OutputBuilder`) to define keyword results.
+
+### Adding output data
+
+```java
+output.add("status", "success");
+output.add("count", 42);
+```
+
+```javascript
+output.add('status', 'success')
+output.add('count', 42)
+```
+
+### Adding attachments
+
+```java
+output.addAttachment(AttachmentHelper.generateAttachmentForException(e));
+```
+
+```javascript
+output.attach({
+    name: 'screenshot.png',
+    description: 'Page screenshot',
+    hexContent: Buffer.from(imageData).toString('base64')
+})
+```
+
+### Setting errors
+
+```java
+output.setBusinessError("Login failed: invalid credentials");
+```
+
+```javascript
+// Simplest approach — sets message AND attaches stack trace
+output.setError(e)
+
+// With custom message
+output.setError('Custom message', e)
+```
+
+---
+
+## Keyword lifecycle and hooks
+
+The execution flow of a keyword:
+
+1. **Initialization** — keyword class is instantiated, inputs and properties are set, session context is attached
+2. **beforeKeyword** (optional) — pre-execution setup (validate inputs, establish connections)
+3. **Keyword function** — the annotated method executes
+4. **onError** (optional) — triggered if an error occurs during execution
+5. **afterKeyword** (optional) — always called after the keyword function, regardless of success or failure (cleanup)
+6. **Instance release** — keyword instance is released, no data retained between executions
+
+### Implementing hooks
+
+**Java**:
+```java
+@Override
+public void beforeKeyword(String keywordName, Keyword annotation) {
+    System.out.println("Calling " + keywordName);
+}
+
+@Override
+public void afterKeyword(String keywordName, Keyword annotation) {
+    takeScreenshot();
+}
+
+@Override
+public boolean onError(Exception e) {
+    output.addAttachment(AttachmentHelper.generateAttachmentForException(e));
+    return true;  // propagate the error
+}
+```
+
+**JavaScript** (module-level exports):
+```javascript
+exports.beforeKeyword = async (functionName) => {
+    console.log('Before:', functionName)
+}
+
+exports.afterKeyword = async (functionName) => {
+    console.log('After:', functionName)
+}
+
+exports.onError = async (exception, input, output, session, properties) => {
+    output.setError(exception)
+    return true  // propagate
+}
+```
+
+---
+
+## Stateless vs stateful keywords
+
+| Feature | Stateless | Stateful |
+|---|---|---|
+| Instance lifecycle | New instance per execution | Data shared via session |
+| Data persistence | None between executions | Persists in session across workflow |
+| Use case | Idempotent, isolated operations | Workflows needing shared state |
+
+### When to use stateful keywords
+
+Use the session when keywords within a workflow need to share state — for example, storing authentication tokens, browser instances, or database connections.
+
+The session is only available when keyword calls are grouped using the `Session` control in a plan. Objects stored in the session must implement `Closeable` or `AutoCloseable` to be cleaned up when the session is released.
+
+**Java**:
+```java
+// Store in session
+session.put("browser", browser);
+
+// Retrieve from session
+WebDriver browser = (WebDriver) session.get("browser");
+```
+
+**JavaScript**:
+```javascript
+// Store in session
+session.set('browser', browser)
+
+// Retrieve from session
+const browser = session.get('browser')
+```
+
+---
+
+## Error handling
+
+### Business errors vs technical errors
+
+- **Business errors** — expected failures in the system under test (login failed, assertion failed). Use `output.setBusinessError()`. Sets keyword status to `FAILED`.
+- **Technical errors** — unexpected exceptions (null pointer, connection timeout). Any uncaught exception is reported as a technical error. Catch and categorize them explicitly when possible.
+
+**Java**:
+```java
+try {
+    // automation logic
+} catch (BusinessException e) {
+    output.setBusinessError(e.getMessage());
+    output.addAttachment(AttachmentHelper.generateAttachmentForException(e));
+} catch (Exception e) {
+    output.setError(e.getMessage());
+    output.addAttachment(AttachmentHelper.generateAttachmentForException(e));
+}
+```
+
+**JavaScript**:
+```javascript
+try {
+    // automation logic
+} catch (e) {
+    output.setError(e)  // sets message + attaches stack trace
+}
+```
+
+---
+
+## Measurements
+
+Measurements track execution timing for analytics. A default measurement is created automatically per keyword execution. Custom measurements provide finer granularity.
+
+Measurements work in a stack — `stopMeasure()` closes the most recently opened one.
+
+**Java**:
+```java
+output.startMeasure("NavigateToPage");
+// do navigation
+output.startMeasure("FillForm");
+// fill the form
+output.stopMeasure();  // stops FillForm
+
+Map<String, String> data = new HashMap<>();
+data.put("username", "Smith");
+output.stopMeasure(data);  // stops NavigateToPage with analytics data
+```
+
+**JavaScript**:
+```javascript
+output.startMeasure('Navigate')
+// do something
+output.stopMeasure()
+
+output.startMeasure('Submit')
+// do something
+output.stopMeasure({ status: 'FAILED' })
+
+// Pre-timed measures
+output.addMeasure('Pre-timed measure', 50)
+output.addMeasure('Pre-timed measure 2', 150, {
+    status: 'TECHNICAL_ERROR',
+    begin: Date.now() - 150,
+    data: { info: 'test' }
+})
+```
+
+Starting with Keyword API version 1.5.0 (Step 29), you can assign an explicit status to individual measurements.
+
+---
+
+## Keyword Proxy (plans as code)
+
+The Keyword Proxy lets a parent keyword invoke child keywords directly from code, creating workflows without using Step plans. Java only.
+
+Key features:
+- Automatically shares the parent keyword's context (session, properties)
+- Manages output propagation (merge all outputs or set manually)
+- Creates measurements for all individual keyword calls
+
+```java
+@Plan
+@Keyword
+public void WorkflowAsCode() {
+    KeywordProxy keywordProxy = new KeywordProxy(this, true);  // true = merge outputs
+    KeywordExample proxy = keywordProxy.getProxy(KeywordExample.class);
+
+    String myInput = getInputOrProperty("myInputString");
+    proxy.myFirstKeyword(3, false, myInput);
+
+    Output<JsonObject> lastOutput = keywordProxy.getLastOutput();
+    if (lastOutput.getPayload().getBoolean("shouldFail")) {
+        output.appendError("The call to myFirstKeyword returned a failure");
+        return;
+    }
+
+    proxy.mySecondKeyword();
+    proxy.myThirdKeyword(List.of("value1", "value2"), Map.of("key1", "val1"));
+}
+```
+
+---
+
+## Live reporting
+
+Live Reporting streams data (log files, measurements) in real time while the keyword runs, as opposed to returning them only after completion. Java API only. Both live and traditional reporting can be combined.
+
+> Live Reporting is under active development and planned for finalization in Step 30. Fully supported on Step infrastructure; local execution support is limited.
+
+See the Keyword API javadoc for streaming file upload and advanced features.
+
+---
+
+## Best practices
+
+### General
+
+- **Minimize dependencies** — keep keywords lightweight
+- **Use meaningful names** — keyword names should clearly reflect their functionality
+
+### Modularity
+
+- Single-purpose keywords increase reusability across workflows but require more development effort
+- Larger keywords wrapping entire workflows are faster to develop but lose modularity
+- Choose based on how many different plans will reuse the keyword
+
+### Resource management
+
+Clean up all resources explicitly — browsers, WebDriver instances, database connections, file handles, downloaded files. Approaches:
+1. Try/finally in the keyword function itself (simplest)
+2. `afterKeyword` hook (always runs, even on failure)
+3. Store resources in session with `Closeable`/`AutoCloseable` — cleaned up when session closes
+
+### Session usage
+
+- Use session properties sparingly to avoid memory overhead
+- Objects stored in session must implement `Closeable` or `AutoCloseable` if they need cleanup
+- Sessions are scoped to the `Session` control in a plan — not globally available
+
+### Accessing Automation Package resources
+
+Java keywords deployed via Automation Packages can retrieve and extract the archive at runtime:
+
+```java
+if (isInAutomationPackage()) {
+    File extractedArchiveFolder = retrieveAndExtractAutomationPackage();
+    // access bundled resources
+}
+```

--- a/wise-mcp/SKILL.md
+++ b/wise-mcp/SKILL.md
@@ -8,7 +8,7 @@ description: Best practices for building MCP servers with FastMCP, informed by b
 This skill guides you through building high-quality MCP servers using FastMCP (Python). It combines two knowledge sources:
 
 - **FastMCP** — the framework for building MCP servers. Docs: https://gofastmcp.com | LLM-optimized: https://gofastmcp.com/llms-full.txt
-- **Arcade patterns** — 52 battle-tested design patterns for building tools that AI agents can use effectively. Reference: https://www.arcade.dev/patterns | LLM-optimized: https://www.arcade.dev/patterns/llm.txt
+- **Arcade patterns** — 54 battle-tested design patterns for building tools that AI agents can use effectively. Reference: https://www.arcade.dev/patterns | LLM-optimized: https://www.arcade.dev/patterns/llm.txt
 
 > **Always check the latest docs before implementing.** Both FastMCP and the arcade patterns evolve. Fetch the LLM-optimized URLs above to get current guidance before writing any MCP server code.
 
@@ -33,6 +33,8 @@ Fetch the latest documentation before writing any code:
 
 These are LLM-optimized text files designed for agent consumption. Use them as your primary reference throughout implementation. API signatures, decorator options, and best practices may have changed since this skill was written.
 
+**Client-only installs:** if you're building a client, agent, script, or library that only needs to talk to MCP (not host a server), use `fastmcp-slim[client]` (FastMCP 3.3+) instead of the full `fastmcp` package. Same `from fastmcp import Client` import; none of the Starlette/Uvicorn server stack is pulled in.
+
 ### 2. Guiding principles
 
 These cross-cutting concerns apply to every decision you make when building MCP servers:
@@ -55,7 +57,7 @@ Know whether each tool is a query, command, or discovery tool. This classificati
 
 - **Query tools** are read-only, safe to retry, and their results can be cached. Mark them clearly so agents know they're side-effect-free. *(see: QUERY_TOOL)*
 - **Command tools** perform actions with side effects. Document what changes, whether the operation is reversible, and whether confirmation is needed for destructive actions. *(see: COMMAND_TOOL)*
-- **Discovery tools** reveal available operations, schemas, or capabilities. Examples: `list_tables()`, `describe_schema()`, `search_tools()`. These are essential for agents working with dynamic or unfamiliar data. With FastMCP 3.1.0+, `BM25SearchTransform` generates a `search_tools` discovery tool automatically — prefer that over hand-written discovery tools for large catalogs. *(see: DISCOVERY_TOOL)*
+- **Discovery tools** reveal available operations, schemas, or capabilities. Examples: `list_tables()`, `describe_schema()`, `search_tools()`. These are essential for agents working with dynamic or unfamiliar data. With FastMCP 3.1+, `BM25SearchTransform` generates a `search_tools` discovery tool automatically — prefer that over hand-written discovery tools for large catalogs. *(see: DISCOVERY_TOOL)*
 
 #### Write LLM-optimized descriptions
 
@@ -67,6 +69,8 @@ The docstring is your tool's interface to the agent. Invest in it:
 - Describe follow-up actions: "After creating a user, call `assign_role()` to set permissions"
 - Include examples of valid inputs for non-obvious parameters
 - Mention performance characteristics: "This tool queries all records — use `search_users()` for filtered results"
+
+Since FastMCP 3.2.4, parameter descriptions are pulled from your docstring automatically. Write a standard `Args:` / `Parameters:` section and the descriptions land in the tool schema — no need to wrap every parameter in `Field(description=...)`.
 
 *(see: TOOL_DESCRIPTION, PERFORMANCE_HINT)*
 
@@ -87,8 +91,22 @@ Every free-form string parameter is an opportunity for the agent to make a mista
 - **Natural identifiers** — let agents pass human-friendly names (email, username, display name) and resolve to system IDs internally. When ambiguous, return candidates with enough context for the agent to choose. *(see: NATURAL_IDENTIFIER, PARAMETER_COERCION)*
 - **Mutual exclusivity** — if parameters conflict ("exactly one of X or Y"), enforce it in validation and document valid combinations clearly. Don't rely on the agent to read the rules. *(see: MUTUAL_EXCLUSIVITY)*
 - **Batch operations** — when agents need to process multiple items, provide a batch variant that accepts arrays and returns per-item results. This saves round trips and reduces token overhead from repeated tool calls. *(see: BATCH_OPERATION)*
+- **Operation mode** — when a tool can run in distinct modes (preview vs. apply, dry-run vs. commit), make the mode an explicit enum parameter rather than a hidden side effect. Document each mode's behavior; never let "what this does" depend on a non-obvious default. *(see: OPERATION_MODE)*
+- **Tool chains** — when several operations must run in a fixed order and the agent shouldn't deviate, expose a single chained tool that runs the sequence with checkpoints. Easier than asking the agent to remember the choreography. *(see: TOOL_CHAIN)*
+- **Scatter-gather** — for queries across multiple backends, expose a single tool that fans out, collects, and merges results. The agent sees one call; you do the orchestration. *(see: SCATTER_GATHER_TOOL)*
+- **Idempotent operations** — design commands to be safely retryable. Accept an idempotency key for non-idempotent operations (creating a payment, sending an email) so agent retries don't duplicate effects. *(see: IDEMPOTENT_OPERATION)*
 
 Refer to FastMCP docs on the `@mcp.tool` decorator, type hints, and parameter schemas for current API details.
+
+### 3a. Execution model
+
+How a tool runs is part of its contract. Agents reason about latency, retry safety, and cancellation just like callers of any other API. Be explicit.
+
+- **Sync vs. async** — FastMCP runs sync tools in a thread pool by default. If a tool holds thread-local state or is bound to a specific thread (UI frameworks, some database drivers), opt out with `@mcp.tool(run_in_thread=False)` (FastMCP 3.3+). *(see: SYNCHRONOUS_EXECUTION)*
+- **Background tasks for long work** — long-running work belongs in a task, not a synchronous tool call. FastMCP's task primitives let the tool return immediately with a handle the agent can poll. **Tasks are scoped to the authorization context, not the session** (FastMCP 3.2.4+), so they survive session churn and stay tied to who started them. *(see: ASYNC_JOB)*
+- **Transactional boundaries** — when a tool performs multiple writes, document whether they are atomic and what state the system is in on partial failure. If it isn't atomic, say so in the description and surface partial-success information in the response. *(see: TRANSACTIONAL_BOUNDARY)*
+- **Compensation handlers** — for non-atomic multi-step tools, expose an undo/compensate tool when feasible. Agents can recover from a partial failure if you give them a reverse operation. *(see: COMPENSATION_HANDLER)*
+- **Timeout boundaries** — set explicit per-tool timeouts. For anything that may exceed a few seconds, call `ctx.report_progress()` so clients don't kill the call on inactivity heuristics. *(see: TIMEOUT_BOUNDARY)*
 
 ### 4. Resources and resource templates
 
@@ -138,7 +156,7 @@ The FastMCP Context object provides session-scoped capabilities within your tool
 
 #### Core capabilities
 
-- **Dependency injection** — use `CurrentContext()` as a default parameter to access the context object. This works in tools, resources, and prompts.
+- **Dependency injection** — use `CurrentContext()` as a default parameter to access the context object. This works in tools, resources, and prompts. *(see: CONTEXT_INJECTION)*
 - **Logging** — use `ctx.info()`, `ctx.warning()`, `ctx.error()` to send structured log messages back to the client. Use these for operational visibility, not for returning data to the agent.
 - **Progress reporting** — use `ctx.report_progress()` for operations that take more than a few seconds. Without progress signals, agents may assume the tool has hung and retry or abort.
 
@@ -153,7 +171,7 @@ Use `ctx.get_state()` / `ctx.set_state()` to persist data across multiple tool c
 
 - **Resource access** — tools can read resources from within their execution context, enabling tools to compose with resources
 - **LLM sampling** — tools can request LLM completions through the context, enabling tools that leverage LLM reasoning as part of their execution
-- **User elicitation** — tools can request input from the end user when they need clarification that the agent can't provide
+- **User elicitation** — tools can request input from the end user when they need clarification that the agent can't provide. Since FastMCP 3.2.4, always pass an explicit `response_type` to `ctx.elicit()` — calling without one is deprecated. Use `response_title` and `response_description` for clearer prompts
 
 Refer to FastMCP docs on the Context object for the full API and current method signatures.
 
@@ -180,6 +198,10 @@ How you return results matters as much as what you return. Agents consume your o
 - **Next-action hints** — suggest what the agent should do next. This is one of the highest-impact patterns. Include suggested tool names, required parameters, and alternative paths in your response. Example: include a `next_steps` field like `["Call assign_role(user_id='abc', role='admin') to complete setup"]`. *(see: NEXT_ACTION_HINT, DEPENDENCY_HINT)*
 - **Partial success** — for batch operations, report per-item status with summary statistics and retry guidance for failures. Never report a batch as simply "failed" when some items succeeded. *(see: PARTIAL_SUCCESS)*
 - **GUI URLs** — when applicable, include links to view or edit results in a web interface. Agents can surface these to users. *(see: GUI_URL)*
+
+### 7a. Interactive apps and UIs
+
+FastMCP 3.2+ tools can return interactive UIs (charts, tables, forms, dashboards) rendered inline in the conversation, plus five built-in providers (`FileUpload`, `Approval`, `Choice`, `FormInput`, `GenerativeUI`) that cover the most common human-in-the-loop patterns. When to reach for which, and how `FastMCPApp` / `@mcp.tool(app=True)` / `fastmcp dev apps` fit together, lives in `references/apps.md`.
 
 ### 8. Error handling and resilience
 
@@ -229,7 +251,7 @@ FastMCP supports composing multiple servers and sourcing components from various
 
 #### Provider system
 
-FastMCP v3.0 uses providers to source components from different origins:
+FastMCP uses providers to source components from different origins:
 
 - **LocalProvider** — the default. Components registered via decorators on the server instance.
 - **FileSystemProvider** — auto-discovers decorated functions from a directory tree. Each file is self-contained. Great for organizing large servers into modular tool files.
@@ -244,13 +266,13 @@ Transforms modify components after provider aggregation:
 - **Visibility** — controls which components are exposed to clients. Use to hide internal or administrative tools. See *Progressive disclosure* below for a full pattern.
 - **VersionFilter** — filters components by version ranges for API evolution
 - **ResourcesAsTools / PromptsAsTools** — exposes resources and prompts as tools for clients that primarily interact via tools
-- **BM25SearchTransform / RegexSearchTransform** *(FastMCP 3.1.0+)* — replaces `list_tools()` with `search_tools` + `call_tool` synthetic tools for large catalogs. BM25 ranks results by relevance; regex uses pattern matching. Use `always_visible` to pin tools that should always appear in `list_tools`. Preferred over the manual Visibility + gateway pattern for most cases — see *Progressive disclosure* below.
+- **BM25SearchTransform / RegexSearchTransform** — replaces `list_tools()` with `search_tools` + `call_tool` synthetic tools for large catalogs. BM25 ranks results by relevance; regex uses pattern matching. Use `always_visible` to pin tools that should always appear in `list_tools`. Preferred over the manual Visibility + gateway pattern for most cases — see *Progressive disclosure* below.
 
 #### Progressive disclosure
 
-When a server has many tools (10+), exposing all of them at startup wastes context window and degrades agent tool-selection accuracy. FastMCP 3.1.0+ provides two approaches.
+When a server has many tools (10+), exposing all of them at startup wastes context window and degrades agent tool-selection accuracy. FastMCP provides two approaches.
 
-**Preferred: Search transforms (FastMCP 3.1.0+)**
+**Preferred: Search transforms**
 
 Use `BM25SearchTransform` or `RegexSearchTransform` to replace `list_tools()` with a minimal interface. Pin the tools agents need immediately with `always_visible`; everything else is discoverable on demand.
 
@@ -269,7 +291,7 @@ mcp.add_transform(BM25SearchTransform(
 
 This approach is client-safe: `always_visible` tools are always in `list_tools` regardless of whether the client supports `ToolListChangedNotification`.
 
-**Alternative: Visibility + gateway (manual, pre-3.1.0)**
+**Alternative: Visibility + gateway (manual)**
 
 For cases where you need category-based opt-in rather than search:
 
@@ -299,6 +321,9 @@ mcp.add_transform(Visibility(True, tags={"gateway"}, components={"tool"}))
 - **Abstraction ladder** — provide tools at multiple granularity levels. Low-level tools for precise control (`create_file`, `write_bytes`), mid-level for common tasks (`create_document`), and high-level for complex workflows (`draft_report`). Let agents choose the right level. *(see: ABSTRACTION_LADDER)*
 - **Task bundles** — combine multiple operations into a single tool when they always occur together. Name after the task, not the steps: `onboard_user()` instead of `create_user_and_assign_role_and_send_welcome_email()`. *(see: TASK_BUNDLE)*
 - **Gateway pattern** — use a parent server as a unified interface to multiple backends. The agent sees one coherent set of tools; the server routes to the right backend. *(see: TOOL_GATEWAY)*
+- **Canonical tool model** — when wrapping multiple similar APIs (multiple ticket systems, multiple file stores), define one internal data model and convert at the boundary. Agents see one consistent shape regardless of backend. *(see: CANONICAL_TOOL_MODEL)*
+- **Tool adapter** — encapsulate per-backend differences in adapter modules behind the canonical model, so adding a new backend doesn't require new agent-facing tools. *(see: TOOL_ADAPTER)*
+- **Tool versioning** — pair with the `VersionFilter` transform. When evolving a tool's signature, expose `tool_v2` alongside `tool_v1` and let `VersionFilter` route clients by capability. Document the deprecation timeline in the older tool's description. *(see: TOOL_VERSIONING)*
 
 Refer to FastMCP docs on server composition, providers, and transforms for implementation details.
 
@@ -308,7 +333,7 @@ Security is enforced in code, never delegated to the agent via prompts. This is 
 
 #### Credential handling
 
-- **Never accept secrets as tool parameters** — API keys, tokens, and passwords flow through the LLM when passed as parameters. Use the Context to inject credentials at runtime. *(see: SECRET_INJECTION)*
+- **Never accept secrets as tool parameters** — API keys, tokens, and passwords flow through the LLM when passed as parameters. Use the Context to inject credentials at runtime. *(see: SECRET_INJECTION, CONTEXT_INJECTION)*
 - **Use environment variables or secure vaults** for credential storage. The tool reads credentials from a trusted source, never from the agent's input.
 
 #### Authorization
@@ -316,13 +341,14 @@ Security is enforced in code, never delegated to the agent via prompts. This is 
 - **Per-tool auth** — use FastMCP's `require_auth` and `require_scopes` decorators on individual tools to enforce fine-grained access control. *(see: PERMISSION_GATE)*
 - **Server-wide policies** — use `AuthMiddleware` to apply blanket authentication requirements. Combine with tag-based restrictions for role-based access.
 - **Scope declaration** — declare required OAuth scopes per tool. Check before execution. Return clear errors that name the missing scope and how to obtain it. *(see: SCOPE_DECLARATION)*
+- **Audience-bound tokens** — for IdPs that don't natively support RFC 8707, set `forward_resource=True` on the OAuth provider (available on all FastMCP OAuth providers as of 3.2) to bind tokens to the MCP resource URL. Prevents cross-resource token reuse — a token issued for server A can't be replayed against server B.
 
 #### Audit and boundaries
 
 - **Audit trail** — log all tool invocations with: what (tool name + redacted parameters), who (user ID + session ID), when (timestamp), and result (success/failure + duration). This is critical for debugging and compliance. *(see: AUDIT_TRAIL)*
 - **Context boundaries** — define explicit scope limits for tool operations. Restrict file access to specific root paths, data access to specific tenants, and API access to specific endpoints. Never let a tool's blast radius exceed what's necessary. *(see: CONTEXT_BOUNDARY)*
 
-Refer to FastMCP docs on authentication, OAuth proxy, middleware, and `require_auth` / `require_scopes` for implementation.
+Refer to FastMCP docs on authentication, OAuth proxy, middleware, `require_auth` / `require_scopes`, and the auth provider catalog (Google, GitHub, AWS Cognito, Azure, Azure AD B2C, Clerk, Keycloak, WorkOS / AuthKit, PropelAuth, Discord, OCI) for implementation.
 
 ### 11. Anti-patterns to avoid
 
@@ -339,3 +365,6 @@ These are the most common mistakes when building MCP servers. Each one degrades 
 - **Security via prompts** — relying on system prompts or tool descriptions to enforce access control. Prompts can be overridden or ignored. Enforce security in code.
 - **Monolithic servers** — putting every tool in one server. Use composition to keep servers focused. An agent connecting to a 50-tool server has worse tool selection accuracy than one connecting to five 10-tool servers via mounting.
 - **Missing next-action hints** — returning results without guidance on what to do next. Every response is an opportunity to help the agent make progress.
+- **Using deprecated tool middlewares** — `PromptToolMiddleware` and `ResourceToolMiddleware` are deprecated as of FastMCP 3.2. Use the `ResourcesAsTools` / `PromptsAsTools` transforms instead.
+- **Calling `ctx.elicit()` without `response_type`** — deprecated as of FastMCP 3.2.4. Always pass an explicit `response_type`; use `response_title` and `response_description` for clearer prompts.
+- **No production discovery surface** — production servers should expose a registry/schema-explorer for runtime tool discovery, capability matching for client negotiation, and a health-check endpoint for monitoring. Easy to forget when iterating on tool design. *(see: TOOL_REGISTRY, SCHEMA_EXPLORER, CAPABILITY_MATCHING, HEALTH_CHECK)*

--- a/wise-mcp/references/apps.md
+++ b/wise-mcp/references/apps.md
@@ -1,0 +1,91 @@
+# Interactive apps and UIs
+
+FastMCP 3.2 ("Show Don't Tool") added a full Apps system on top of the regular tool/resource/prompt primitives. A tool can return an interactive UI — chart, table, form, dashboard — that renders inline in the conversation. The UI is built with [Prefab](https://prefab.prefect.io), a Python component library that compiles to a web UI. FastMCP handles the MCP Apps protocol machinery (renderer resources, CSP configuration, structured content serialization).
+
+Two ways to expose UIs, plus five ready-made providers.
+
+## `app=True` on a regular tool
+
+Simplest case. Return a `PrefabApp` containing chart/table/layout components. No server round-trip after rendering — best for one-shot visualizations.
+
+```python
+from fastmcp import FastMCP
+from prefab_ui.components import BarChart, ChartSeries, PrefabApp
+
+mcp = FastMCP("Analytics")
+
+@mcp.tool(app=True)
+def revenue_chart(year: int) -> PrefabApp:
+    with PrefabApp() as app:
+        BarChart(data=revenue_data, series=[ChartSeries(data_key="revenue")])
+    return app
+```
+
+Use this when:
+
+- You want to show data, not interact with it
+- The agent has already gathered the data; the user just needs to see it
+- A static chart, table, or dashboard is enough
+
+## `FastMCPApp` provider — UIs that call backend tools
+
+Full pattern for UIs that submit forms, trigger backend work, or maintain state across interactions. `@app.ui()` registers an LLM-visible tool that renders a UI; `@app.tool()` registers backend tools the UI calls (form submissions, button handlers, refresh actions). Visibility is managed automatically — the LLM sees only the UI entry points, not the backend handlers. Tool references survive namespace transforms and server composition.
+
+```python
+from fastmcp import FastMCP, FastMCPApp
+from prefab_ui.actions.mcp import CallTool
+from prefab_ui.components import (
+    Button, Column, ForEach, Form, Input, PrefabApp, Text,
+)
+
+app = FastMCPApp("Contacts")
+db: list[dict] = []
+
+@app.tool()
+def save_contact(name: str, email: str) -> list[dict]:
+    db.append({"name": name, "email": email})
+    return list(db)
+
+@app.ui()
+def contact_manager() -> PrefabApp:
+    with PrefabApp(state={"contacts": list(db)}) as view:
+        with Column(gap=4):
+            ForEach("contacts", lambda c: Text(c.name))
+            with Form(on_submit=CallTool("save_contact")):
+                Input(name="name", required=True)
+                Input(name="email", required=True)
+                Button("Save")
+    return view
+
+mcp = FastMCP("Server", providers=[app])
+```
+
+## Built-in providers — reusable human-in-the-loop primitives
+
+Five ready-made providers, each added with a single `add_provider()` call. Prefer these over hand-rolling equivalents.
+
+- **`FileUpload`** — drag-and-drop file upload with session-scoped storage. Registers `file_manager` (upload UI), `list_files`, and `read_file`. Use it instead of asking the agent to paste large content as a parameter — bypasses the LLM context window entirely.
+- **`Approval`** — human-in-the-loop confirmation gate. The LLM proposes an action, the user approves or rejects via buttons, and the decision flows back as a message. Use for irreversible operations: deletes, payments, anything you can't undo.
+- **`Choice`** — present clickable options instead of asking the LLM to elicit a free-text choice. Pairs naturally with the `CONFIRMATION_REQUEST` pattern (see `SKILL.md` §8) when input could match multiple entities.
+- **`FormInput`** — generate validated forms from Pydantic models. Submissions are validated against the model before they return. Supports default prefill values (FastMCP 3.3+). Use for structured data collection that would be error-prone via free-text.
+- **`GenerativeUI`** — the LLM writes Prefab component code at runtime and the result streams to the user as generated. Use for one-off custom UIs that don't justify a hand-coded `@app.ui()` tool.
+
+## Development workflow
+
+`fastmcp dev apps` launches a browser-based preview for your app tools — pick a tool, supply arguments, and see the rendered UI without connecting to a real MCP host. Includes a built-in MCP message inspector for debugging the protocol traffic.
+
+## Version pinning
+
+`prefab-ui` is on a faster release cadence than FastMCP itself. Pin a specific version explicitly in your project dependencies — don't rely on a transitive range — and bump it deliberately when you upgrade FastMCP. Component API changes between Prefab minor versions are possible.
+
+## Anti-patterns
+
+- **Putting large content in parameters when `FileUpload` is available.** If a user needs to provide a CSV, a PDF, or an image, route it through `FileUpload`, not through a parameter the agent will paste into context.
+- **Skipping `Approval` for irreversible actions.** A confirmation gate costs one extra UI message and prevents an agent's incorrect tool call from causing real damage.
+- **Building custom forms when `FormInput` would do.** If the input shape is a Pydantic model, the built-in provider validates the submission for free. Don't reinvent it.
+
+## Authoritative docs
+
+- FastMCP Apps overview, `FastMCPApp` API, Prefab component catalog: <https://gofastmcp.com/llms-full.txt>
+- v3.2.0 "Show Don't Tool" release notes (introduction of Apps): <https://github.com/PrefectHQ/fastmcp/releases/tag/v3.2.0>
+- v3.3.0 "Slim Reaper" release notes (`FormInput` prefill, fixes): <https://github.com/PrefectHQ/fastmcp/releases/tag/v3.3.0>


### PR DESCRIPTION
chore(tooling): wire ruff and ty into pre-push hooks and CI

Add [tool.ruff] (target-version py314, line-length 100) and
[tool.ty.environment] (python-version 3.14) to pyproject.toml so
manual `uvx` runs and the new prek hooks share one project policy.

Add astral-sh/ruff-pre-commit@v0.15.13 (ruff-check + ruff-format
--check) and a local `ty` hook running `uvx ty check .` to prek.toml,
both gated to the pre-push stage (no auto-fix on push).

Extend the GitHub Actions prek extra-args to include ruff-check,
ruff-format, and ty so the new hooks run in CI too. Update CLAUDE.md
to mention the new hooks in the Commands and CI sections.

chore(scripts): harden validate_skills.py with spec-adherence checks

The previous validator (44 lines) just shelled out to `agentskills
validate`, which only checks frontmatter regex and reserved words.
This rewrite layers spec and best-practices checks on top, each finding
citing the spec section it comes from
(agentskills.io/specification or platform.claude.com/.../best-practices).

Errors (block CI):
- name field matches parent directory
- description in third person with a "Use when" trigger phrase
- SKILL.md body ≤ 500 lines and ≤ 5000 words
- markdown links resolve and stay inside the skill dir
- references stay one level deep
- no Windows backslash paths
- reserved words (anthropic, claude) in name
- compatibility ≤ 500 chars

Warnings:
- reference files > 100 lines without a Contents heading
- unrecognized top-level subdirectories
- time-sensitive phrasing ("after March 2026" etc.) in body

Current state: git-spice, step-dev, wise-mcp pass clean.
macos-expert has 6 warnings (reference files lacking TOCs).

docs(wise-mcp): refresh for FastMCP 3.3.0 and 54-pattern Arcade catalog

FastMCP coverage:
- Apps system (3.2.0): FastMCPApp / app=True / Prefab — detail
  factored into wise-mcp/references/apps.md so SKILL.md stays under
  the 500-line cap
- Built-in providers named alongside Apps: FileUpload, Approval,
  Choice, FormInput, GenerativeUI
- Auto-docstring param extraction (3.2.4)
- ctx.elicit() response_type deprecation (3.2.4)
- Auth-scoped tasks (3.2.4)
- run_in_thread=False opt-out (3.3+)
- fastmcp-slim client distribution (3.3+)
- Expanded auth provider catalog (+AzureB2C, Clerk, Keycloak)
- forward_resource RFC 8707 audience binding
- Stale FastMCP 3.1.0+ / v3.0 markers dropped throughout

Arcade coverage: pattern count bumped from 52 to 54; named pattern
references expanded from 37 to 53 (all 10 categories represented).
Added new Execution model section covering the previously-missing
TOOL EXECUTION category (SYNCHRONOUS_EXECUTION, ASYNC_JOB,
IDEMPOTENT_OPERATION, TRANSACTIONAL_BOUNDARY, COMPENSATION_HANDLER,
TIMEOUT_BOUNDARY). Added OPERATION_MODE, TOOL_CHAIN,
SCATTER_GATHER_TOOL, CANONICAL_TOOL_MODEL, TOOL_ADAPTER,
TOOL_VERSIONING, CONTEXT_INJECTION, TOOL_REGISTRY, SCHEMA_EXPLORER,
CAPABILITY_MATCHING, HEALTH_CHECK references.

Passes the hardened validator clean.

style(validator): apply ruff format under 100-char line limit

Earlier ruff format ran before [tool.ruff] line-length=100 was added
to pyproject.toml, leaving lines broken at the 88-char default. Rejoin
them so ruff-format --check (now a pre-push hook) is clean.

No behavioral changes — pure formatting.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ruff and ty checks to pre-push hooks and CI
> Wires `ruff-check`, `ruff-format`, and `ty check` into the pre-push hook configuration in [prek.toml](https://github.com/detailobsessed/agent-skills/pull/12/files#diff-72359463e1c50ddcb8dfabe900898a8f1d92416bbe6754f2e497f62d96232021) and the CI workflow in [.github/workflows/ci.yml](https://github.com/detailobsessed/agent-skills/pull/12/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f). Ruff and ty settings (target Python 3.14, line-length 100) are codified in [pyproject.toml](https://github.com/detailobsessed/agent-skills/pull/12/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0daa72f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->